### PR TITLE
Fix sign-in link visibility on desktop

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -84,7 +84,7 @@ const Header = ({ onLogoClick }: HeaderProps) => {
             </UserButton>
           </SignedIn>
           <SignedOut>
-            <Link href="/sign-in" className="text-sm hover:underline">
+            <Link href="/sign-in" className="text-sm text-white/90 hover:text-white hover:underline">
               Sign In
             </Link>
           </SignedOut>


### PR DESCRIPTION
## Summary
- The desktop "Sign In" link in the header was nearly invisible against the dark gradient background
- Added explicit `text-white/90` with `hover:text-white` for proper contrast

## Test plan
- [ ] Verify "Sign In" text is clearly visible on the desktop landing page when signed out
- [ ] Verify hover state shows full white text with underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)