### PR TITLE
Standardize wardrobe detail placeholders to em dash

### DIFF
--- a/src/components/wardrobe/item-detail/GarmentDetails.tsx
+++ b/src/components/wardrobe/item-detail/GarmentDetails.tsx
@@ -11,7 +11,7 @@ export function GarmentDetails({ details }: { details: WardrobeItem["details"] }
     ? details.garment_thermal_properties[0]
     : details.garment_thermal_properties;
   const coverageAreas = getGarmentCoverageAreas(details);
-  const coverageSummary = coverageAreas.length > 0 ? `${coverageAreas.length} areas` : "N/A";
+  const coverageSummary = coverageAreas.length > 0 ? `${coverageAreas.length} areas` : "—";
   const coverageDetail = coverageAreas.length > 0 ? coverageAreas.join(" • ") : "No coverage metadata";
 
   return (

--- a/src/components/wardrobe/item-detail/HandwearDetails.tsx
+++ b/src/components/wardrobe/item-detail/HandwearDetails.tsx
@@ -14,13 +14,13 @@ export function HandwearDetails({ details }: { details: WardrobeItem["details"] 
         <div className="rounded-lg border border-border/60 bg-background/65 px-2.5 py-2">
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Dexterity</p>
           <p className="mt-1 text-sm font-semibold">
-            {details.dexterity_score !== undefined ? `${details.dexterity_score}/10` : "N/A"}
+            {details.dexterity_score !== undefined ? `${details.dexterity_score}/10` : "—"}
           </p>
         </div>
         <div className="rounded-lg border border-border/60 bg-background/65 px-2.5 py-2">
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Type</p>
           <p className="mt-1 truncate text-sm font-semibold">
-            {details.handwear_type?.replace(/_/g, " ") ?? "N/A"}
+            {details.handwear_type?.replace(/_/g, " ") ?? "—"}
           </p>
         </div>
       </div>
@@ -42,7 +42,7 @@ export function HandwearDetails({ details }: { details: WardrobeItem["details"] 
             <tr className="bg-background/75">
               <td className="px-3 py-1.5 text-muted-foreground">Dexterity Score</td>
               <td className="px-3 py-1.5 text-right font-mono font-medium">
-                {details.dexterity_score !== undefined ? `${details.dexterity_score}/10` : "N/A"}
+                {details.dexterity_score !== undefined ? `${details.dexterity_score}/10` : "—"}
               </td>
             </tr>
           </tbody>

--- a/src/components/wardrobe/item-detail/HeadwearDetails.tsx
+++ b/src/components/wardrobe/item-detail/HeadwearDetails.tsx
@@ -15,7 +15,7 @@ export function HeadwearDetails({ details }: { details: WardrobeItem["details"] 
         </div>
         <div className="rounded-lg border border-border/60 bg-background/65 px-2.5 py-2">
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Coverage</p>
-          <p className="mt-1 text-sm font-semibold">{coverage.length > 0 ? `${coverage.length} areas` : "N/A"}</p>
+          <p className="mt-1 text-sm font-semibold">{coverage.length > 0 ? `${coverage.length} areas` : "—"}</p>
           <p className="truncate text-[11px] text-muted-foreground">
             {coverage.length > 0 ? coverage.join(" • ") : "No coverage metadata"}
           </p>
@@ -23,7 +23,7 @@ export function HeadwearDetails({ details }: { details: WardrobeItem["details"] 
         <div className="rounded-lg border border-border/60 bg-background/65 px-2.5 py-2">
           <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Type</p>
           <p className="mt-1 truncate text-sm font-semibold">
-            {details.headwear_type?.replace(/_/g, " ") ?? "N/A"}
+            {details.headwear_type?.replace(/_/g, " ") ?? "—"}
           </p>
         </div>
       </div>
@@ -44,15 +44,15 @@ export function HeadwearDetails({ details }: { details: WardrobeItem["details"] 
           <tbody>
             <tr className="bg-background/75">
               <td className="px-3 py-1.5 text-muted-foreground">Ears</td>
-              <td className="px-3 py-1.5 text-right font-medium">{details.covers_ears ? "Covered" : "N/A"}</td>
+              <td className="px-3 py-1.5 text-right font-medium">{details.covers_ears ? "Covered" : "—"}</td>
             </tr>
             <tr className="bg-muted/10">
               <td className="px-3 py-1.5 text-muted-foreground">Neck</td>
-              <td className="px-3 py-1.5 text-right font-medium">{details.covers_neck ? "Covered" : "N/A"}</td>
+              <td className="px-3 py-1.5 text-right font-medium">{details.covers_neck ? "Covered" : "—"}</td>
             </tr>
             <tr className="bg-background/75">
               <td className="px-3 py-1.5 text-muted-foreground">Face</td>
-              <td className="px-3 py-1.5 text-right font-medium">{details.covers_face ? "Covered" : "N/A"}</td>
+              <td className="px-3 py-1.5 text-right font-medium">{details.covers_face ? "Covered" : "—"}</td>
             </tr>
           </tbody>
         </table>

--- a/src/components/wardrobe/item-detail/detail-formatters.ts
+++ b/src/components/wardrobe/item-detail/detail-formatters.ts
@@ -4,7 +4,7 @@ export function formatDetailValue(
   value: number | undefined | null,
   decimals: number = 2
 ): string {
-  if (value === undefined || value === null) return "N/A";
+  if (value === undefined || value === null) return "—";
   return value.toFixed(decimals);
 }
 


### PR DESCRIPTION
## Summary
- Replaces all `"N/A"` null/empty placeholders with `"—"` (em dash) across wardrobe detail components
- Aligns `formatDetailValue()` in `detail-formatters.ts` with the `formatValue()`/`formatConfidence()`/`formatEstimationMethod()` functions in `wardrobe-utils.tsx` that already used `"—"`
- Legitimate zero values (e.g., `0.00` clo) continue to display as numbers — only null/undefined values show `—`

Fixes #46

## Test plan
- [ ] Open wardrobe detail view for a garment with complete data — values should show numbers, not `—`
- [ ] Open detail view for a garment with missing thermal properties — should show `—` consistently
- [ ] Check handwear details with missing dexterity/type — should show `—`
- [ ] Check headwear details with no coverage flags — ears/neck/face should show `—`
- [ ] Verify Data Quality table still shows `—` for missing method/confidence (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)