### PR TITLE
Fix layer placement to use garment's native layer type

### DIFF
--- a/src/components/LayerDisplay.tsx
+++ b/src/components/LayerDisplay.tsx
@@ -494,7 +494,8 @@ const LayerDisplay = ({
 
   const handlePickerSelect = useCallback((item: PickerItem) => {
     if (!pickerTarget) return;
-    const { bodyPart: bp, layerType: lt, replaceIndex, phase } = pickerTarget;
+    const { bodyPart: bp, replaceIndex, phase } = pickerTarget;
+    const lt = item.nativeLayerType;
     const newItem = {
       name: item.name,
       rcl: item.rcl,

--- a/src/hooks/useLayerPicker.ts
+++ b/src/hooks/useLayerPicker.ts
@@ -16,6 +16,7 @@ export interface PickerItem {
   name: string;
   brand: string;
   rcl: number;
+  nativeLayerType: LayerType;
   isInUse: boolean;
   isOwned: boolean;
 }
@@ -142,6 +143,7 @@ export function useLayerPicker(inUseItemIds: Set<string>) {
           name: item.nickname || item.details.model_name,
           brand: item.details.brand,
           rcl: getRegionalClo(item, bodyPart),
+          nativeLayerType: wardrobeLayerType(item) ?? layerType,
           isInUse: inUseItemIds.has(item.item_id),
           isOwned: true,
         }))
@@ -163,6 +165,7 @@ export function useLayerPicker(inUseItemIds: Set<string>) {
             name: item.model_name,
             brand: item.brand,
             rcl: regionalRcl ?? item.rcl_clo ?? 0,
+            nativeLayerType: inferAvailableLayer(item),
             isInUse: inUseItemIds.has(item.id),
             isOwned: false,
           };


### PR DESCRIPTION
## Summary
- Fixed bug where adding a garment from the layer picker placed it in the clicked section's layer type instead of the garment's actual layer category
- Added `nativeLayerType` to `PickerItem` interface, populated from `wardrobeLayerType()` and `inferAvailableLayer()`
- `handlePickerSelect` now uses `item.nativeLayerType` for correct placement

Closes #62

## Test plan
- [x] Open layer recommendations, click "Add base layer", select a mid-layer item → verify it appears in the mid layer section
- [x] Repeat for other layer sections (mid, outer) with cross-layer items
- [x] Test replace flow: replace an item with one from a different native layer category
- [x] Verify extremity items (headwear, handwear) still place correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layer assignment for wardrobe items to correctly identify their native layer type, ensuring items are placed in the appropriate layers based on their inherent properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->