### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ ios/App/App.xcworkspace/xcuserdata/
 
 # clerk configuration (can include secrets)
 /.clerk/
+
+# Claude
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` to `.gitignore` to keep Claude Code project instructions out of version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration files.

---

**Note:** This release contains no user-facing changes. The update is limited to internal development configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->