### PR TITLE
Fix cold risk warnings within target ranges

### DIFF
--- a/src/components/LayerDisplay.test.tsx
+++ b/src/components/LayerDisplay.test.tsx
@@ -660,6 +660,14 @@ describe("LayerDisplay", () => {
           ...mockBiophysicsData.ireq,
           // Lower target range so effectiveTotalClo (~1.3) falls in range
           target_range: [1.0, 1.5] as [number, number],
+          regional: {
+            min: { torso: 1.0, arms: 0.8, legs: 0.9 },
+            neutral: { torso: 1.45, arms: 1.2, legs: 1.3 },
+          },
+          extremity: {
+            min: { hands: 0.5, head: 0.4 },
+            neutral: { hands: 0.85, head: 0.57 },
+          },
         },
         recommendation: {
           ...mockBiophysicsData.recommendation,
@@ -699,6 +707,37 @@ describe("LayerDisplay", () => {
       expect(screen.getByText("Optimal")).toBeInTheDocument();
     });
 
+    it("should not show cold risk when the whole-body and body-part gaps stay within display tolerance", () => {
+      const nearTargetData = {
+        ...mockBiophysicsData,
+        ireq: {
+          ...mockBiophysicsData.ireq,
+          target_range: [1.0, 1.5] as [number, number],
+          regional: {
+            min: { torso: 1.0, arms: 0.8, legs: 0.2 },
+            neutral: { torso: 1.46, arms: 1.23, legs: 0.28 },
+          },
+          extremity: {
+            min: { hands: 0.5, head: 0.4 },
+            neutral: { hands: 0.69, head: 0.57 },
+          },
+        },
+      };
+
+      render(
+        <LayerDisplay
+          recommendation={null}
+          temperature={40}
+          windspeed={11}
+          biophysicsData={nearTargetData}
+        />
+      );
+
+      expect(screen.getByText("Optimal")).toBeInTheDocument();
+      expect(screen.queryByLabelText(/Cold Risk/)).not.toBeInTheDocument();
+      expect(screen.queryByText("Cold Stress")).not.toBeInTheDocument();
+    });
+
     it("should not show comfort achieved when total clo is in range but a region is under target", () => {
       render(
         <LayerDisplay
@@ -719,6 +758,10 @@ describe("LayerDisplay", () => {
         ireq: {
           ...mockBiophysicsData.ireq,
           target_range: [0.8, 1.3] as [number, number],
+          extremity: {
+            min: { hands: 0.5, head: 0.4 },
+            neutral: { hands: 0.68, head: 0.56 },
+          },
           downhill: { min: 1.0, neutral: 1.6 },
           downhill_target_range: [1.0, 1.6] as [number, number],
         },
@@ -747,8 +790,6 @@ describe("LayerDisplay", () => {
 
       expect(screen.getAllByText("Climb").length).toBeGreaterThan(0);
       expect(screen.getAllByText("Descent").length).toBeGreaterThan(0);
-      expect(screen.queryByText(/Climb Cold Risk/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/Descent.*Risk/)).not.toBeInTheDocument();
       // Old descent section removed — descent tab and "In the Pack" summary replace it
       expect(screen.queryByText("Descent Layer Plan")).not.toBeInTheDocument();
       // Pack item visible in climb tab via "In the Pack" summary

--- a/src/components/LayerDisplay.tsx
+++ b/src/components/LayerDisplay.tsx
@@ -27,10 +27,9 @@ import {
   LayerItem,
 } from "@/lib/layers";
 import {
-  EXTREMITY_DEFICIT_CLO_THRESHOLD,
-  REGIONAL_DEFICIT_CLO_THRESHOLD,
   calculateThermalComfortScore,
   evaluateThermalComfort,
+  THERMAL_DISPLAY_CLO_EPSILON,
 } from "@/lib/biophysics/comfort";
 import { ENSEMBLE_REGRESSION, REGIONAL_WEIGHTS } from "@/lib/biophysics/constants";
 import { ACTIVITIES } from "@/data/activities";
@@ -102,75 +101,6 @@ function getImmediateAction(state: ThermalDecisionState | null): string {
   return state.severity === "high"
     ? "Remove a warm layer and open vents immediately."
     : "Drop one layer or increase venting to avoid overheating.";
-}
-
-type CloStatusKind = "need" | "over" | "inRange";
-interface CloStatus {
-  kind: CloStatusKind;
-  delta: number;
-  label: string;
-  phrase: string;
-  className: string;
-}
-
-function getCloStatus(
-  totalClo: number | undefined,
-  targetRange: [number, number] | undefined
-): CloStatus | null {
-  if (totalClo === undefined || !targetRange) return null;
-
-  const [targetMin, targetMax] = targetRange;
-  const CLO_EPSILON = 0.05;
-  const deficitRaw = targetMin - totalClo;
-  const surplusRaw = totalClo - targetMax;
-  const deficit = deficitRaw > CLO_EPSILON ? deficitRaw : 0;
-  const surplus = surplusRaw > CLO_EPSILON ? surplusRaw : 0;
-
-  if (deficit > 0) {
-    return {
-      kind: "need",
-      delta: deficit,
-      label: `Need +${deficit.toFixed(1)} clo`,
-      phrase: "cold",
-      className: "border-sky-200 bg-sky-50/95 text-sky-800",
-    };
-  }
-
-  if (surplus > 0) {
-    return {
-      kind: "over",
-      delta: surplus,
-      label: `Over +${surplus.toFixed(1)} clo`,
-      phrase: "warm",
-      className: "border-amber-200 bg-amber-50/95 text-amber-800",
-    };
-  }
-
-  return {
-    kind: "inRange",
-    delta: 0,
-    label: "In target range",
-    phrase: "in range",
-    className: "border-emerald-200 bg-emerald-50/95 text-emerald-800",
-  };
-}
-
-function getDecisionFromCloStatus(status: CloStatus | null): ThermalDecisionState | null {
-  if (!status) return null;
-
-  if (status.kind === "inRange") {
-    return {
-      riskType: "comfortable",
-      severity: "moderate",
-      delta: 0,
-    };
-  }
-
-  return {
-    riskType: status.kind === "need" ? "cold" : "overheat",
-    severity: status.delta >= 0.35 ? "high" : "moderate",
-    delta: status.delta,
-  };
 }
 
 /**
@@ -630,8 +560,8 @@ const LayerDisplay = ({
 
   const maxRegionalDeficit = Math.max(torsoDeficit, armsDeficit, legsDeficit);
   const maxExtremityDeficit = Math.max(handsDeficit, headDeficit);
-  const hasRegionalGap = maxRegionalDeficit > REGIONAL_DEFICIT_CLO_THRESHOLD;
-  const hasExtremityGap = maxExtremityDeficit > EXTREMITY_DEFICIT_CLO_THRESHOLD;
+  const hasRegionalGap = maxRegionalDeficit > THERMAL_DISPLAY_CLO_EPSILON;
+  const hasExtremityGap = maxExtremityDeficit > THERMAL_DISPLAY_CLO_EPSILON;
 
   // Calculate effectiveTotalClo using the same method as the breakdown
   // This ensures the "Actual" badge matches the breakdown "Total"
@@ -662,8 +592,7 @@ const LayerDisplay = ({
     ?? biophysicsData?.recommendation?.score;
 
   // Calculate climb/descent decisions for dual-gauge view
-  const climbStatus = showDualComfortGauges ? getCloStatus(effectiveTotalClo, uphillTargetRange) : null;
-  const climbDecision = showDualComfortGauges ? getDecisionFromCloStatus(climbStatus) : null;
+  const climbDecision = showDualComfortGauges ? thermalDecision : null;
 
   // Determine which decision to use for risk card
   const decisionForRiskCard = showDualComfortGauges ? climbDecision : thermalDecision;
@@ -727,9 +656,32 @@ const LayerDisplay = ({
     estimatedDescentClo = torso * wt.torso + arms * wt.arm + legs * wt.leg;
   }
 
-  // Now compute descent status using the refined estimatedDescentClo
-  const descentStatus = showDualComfortGauges ? getCloStatus(estimatedDescentClo, downhillTargetRange) : null;
-  const descentDecision = showDualComfortGauges ? getDecisionFromCloStatus(descentStatus) : null;
+  const descentTorsoSection = descentBodyPartSections.find((s) => s.part === "torso");
+  const descentLegsSection = descentBodyPartSections.find((s) => s.part === "legs");
+  const descentHandsSection = descentBodyPartSections.find((s) => s.part === "hands");
+  const descentHeadNeckSection = descentBodyPartSections.find((s) => s.part === "headNeck");
+  const descentArmsDeficit = getRegionalDeficit(
+    descentBreakdown?.regional_ireq?.neutral?.arms ?? regionalIreq?.neutral?.arms,
+    descentBreakdown?.regional_clo?.arms ?? regionalClo?.arms
+  );
+  const descentMaxRegionalDeficit = Math.max(
+    getRegionalDeficit(descentTorsoSection?.targetClo, descentTorsoSection?.currentClo),
+    descentArmsDeficit,
+    getRegionalDeficit(descentLegsSection?.targetClo, descentLegsSection?.currentClo)
+  );
+  const descentMaxExtremityDeficit = Math.max(
+    getRegionalDeficit(descentHandsSection?.targetClo, descentHandsSection?.currentClo),
+    getRegionalDeficit(descentHeadNeckSection?.targetClo, descentHeadNeckSection?.currentClo)
+  );
+
+  const descentDecision = showDualComfortGauges
+    ? evaluateThermalComfort({
+        totalClo: estimatedDescentClo,
+        targetRange: downhillTargetRange,
+        maxRegionalDeficit: descentMaxRegionalDeficit,
+        maxExtremityDeficit: descentMaxExtremityDeficit,
+      })
+    : null;
   const descentRiskTitle = descentDecision
     ? descentDecision.riskType === "comfortable"
       ? "Descent In Target Range"

--- a/src/components/ScoreDisplay.tsx
+++ b/src/components/ScoreDisplay.tsx
@@ -7,6 +7,7 @@ import {
   evaluateThermalComfort,
   OVERHEAT_BUFFER_CLO,
   REGIONAL_DEFICIT_CLO_THRESHOLD,
+  THERMAL_DISPLAY_CLO_EPSILON,
 } from "@/lib/biophysics/comfort";
 import {
   Popover,
@@ -84,10 +85,10 @@ const ScoreDisplay = ({
 
   const getStatus = (): ThermalStatus => {
     const inferredRegionalDeficit = regionalDeficit ?? (
-      hasRegionalGap ? REGIONAL_DEFICIT_CLO_THRESHOLD + 0.01 : 0
+      hasRegionalGap ? THERMAL_DISPLAY_CLO_EPSILON + 0.01 : 0
     );
     const inferredExtremityDeficit = extremityDeficit ?? (
-      hasExtremityGap ? EXTREMITY_DEFICIT_CLO_THRESHOLD + 0.01 : 0
+      hasExtremityGap ? THERMAL_DISPLAY_CLO_EPSILON + 0.01 : 0
     );
     const decision = evaluateThermalComfort({
       totalClo,
@@ -151,11 +152,12 @@ const ScoreDisplay = ({
             {config.description}
           </p>
           <p className="text-slate-500">
-            Status logic uses the same thermal decision kernel as recommendation scoring.
-            Regional deficits above {REGIONAL_DEFICIT_CLO_THRESHOLD.toFixed(2)} clo or
-            extremity deficits above {EXTREMITY_DEFICIT_CLO_THRESHOLD.toFixed(2)} clo
-            override whole-body comfort status. Overheating only triggers above target max +
-            {OVERHEAT_BUFFER_CLO.toFixed(1)} clo.
+            Cold warnings show when total insulation falls more than {THERMAL_DISPLAY_CLO_EPSILON.toFixed(2)} clo
+            below the target band or a body part falls more than {THERMAL_DISPLAY_CLO_EPSILON.toFixed(2)} clo
+            below its target. Score penalties still ramp up once regional deficits exceed{" "}
+            {REGIONAL_DEFICIT_CLO_THRESHOLD.toFixed(2)} clo or extremity deficits exceed{" "}
+            {EXTREMITY_DEFICIT_CLO_THRESHOLD.toFixed(2)} clo. Overheating only triggers above
+            target max + {OVERHEAT_BUFFER_CLO.toFixed(1)} clo.
           </p>
           {totalClo !== undefined && targetRange && (
             <p className="text-slate-500">
@@ -173,7 +175,7 @@ const ScoreDisplay = ({
             </div>
             <div className="flex items-center gap-2 text-slate-600">
               <span className="size-2 rounded-full bg-blue-500" />
-              <span>Cold stress: below min or local deficit (torso/arms/legs/hands/head)</span>
+              <span>Cold stress: outside target band or a body part is below target</span>
             </div>
             <div className="flex items-center gap-2 text-slate-600">
               <span className="size-2 rounded-full bg-amber-500" />

--- a/src/lib/biophysics/comfort.test.ts
+++ b/src/lib/biophysics/comfort.test.ts
@@ -17,16 +17,40 @@ describe("getMaxExtremityDeficit", () => {
 });
 
 describe("evaluateThermalComfort", () => {
-  it("marks cold risk when extremity deficit exceeds threshold even if whole-body is in range", () => {
+  it("marks cold risk when a body-part target is visibly missed even if whole-body is in range", () => {
     const result = evaluateThermalComfort({
       totalClo: 1.6,
       targetRange: [1.5, 1.9],
       maxRegionalDeficit: 0.02,
-      maxExtremityDeficit: 0.2,
+      maxExtremityDeficit: 0.06,
     });
 
     expect(result?.riskType).toBe("cold");
-    expect(result?.delta).toBeCloseTo(0.2, 5);
+    expect(result?.delta).toBeCloseTo(0.06, 5);
+  });
+
+  it("stays comfortable when whole-body and local deficits are within the display tolerance", () => {
+    const result = evaluateThermalComfort({
+      totalClo: 1.48,
+      targetRange: [1.5, 1.9],
+      maxRegionalDeficit: 0.04,
+      maxExtremityDeficit: 0.03,
+    });
+
+    expect(result?.riskType).toBe("comfortable");
+    expect(result?.delta).toBe(0);
+  });
+
+  it("prioritizes overheating when total clo is clearly above range", () => {
+    const result = evaluateThermalComfort({
+      totalClo: 2.3,
+      targetRange: [1.5, 1.9],
+      maxRegionalDeficit: 0.04,
+      maxExtremityDeficit: 0.08,
+    });
+
+    expect(result?.riskType).toBe("overheat");
+    expect(result?.delta).toBeCloseTo(0.4, 5);
   });
 });
 

--- a/src/lib/biophysics/comfort.ts
+++ b/src/lib/biophysics/comfort.ts
@@ -1,6 +1,7 @@
 export const REGIONAL_DEFICIT_CLO_THRESHOLD = 0.12;
 export const EXTREMITY_DEFICIT_CLO_THRESHOLD = 0.1;
 export const OVERHEAT_BUFFER_CLO = 0.3;
+export const THERMAL_DISPLAY_CLO_EPSILON = 0.05;
 
 export type ThermalRiskType = "comfortable" | "cold" | "overheat";
 export type ThermalRiskSeverity = "moderate" | "high";
@@ -22,8 +23,26 @@ export interface ThermalComfortDecision {
   delta: number;
 }
 
+interface ThermalComfortInput {
+  totalClo: number | undefined;
+  targetRange: [number, number] | undefined;
+  maxRegionalDeficit?: number;
+  maxExtremityDeficit?: number;
+  regionalDeficitThreshold?: number;
+  extremityDeficitThreshold?: number;
+  overheatBufferClo?: number;
+}
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function getRangeWidth(targetRange: [number, number]): number {
+  return Math.max(0.2, targetRange[1] - targetRange[0]);
+}
+
+function getSeverity(delta: number, targetRange: [number, number]): ThermalRiskSeverity {
+  return delta <= getRangeWidth(targetRange) ? "moderate" : "high";
 }
 
 export function getMaxRegionalDeficit(
@@ -53,15 +72,7 @@ export function getMaxExtremityDeficit(
   );
 }
 
-export function evaluateThermalComfort(input: {
-  totalClo: number | undefined;
-  targetRange: [number, number] | undefined;
-  maxRegionalDeficit?: number;
-  maxExtremityDeficit?: number;
-  regionalDeficitThreshold?: number;
-  extremityDeficitThreshold?: number;
-  overheatBufferClo?: number;
-}): ThermalComfortDecision | null {
+function evaluateThermalComfortScoreState(input: ThermalComfortInput): ThermalComfortDecision | null {
   const {
     totalClo,
     targetRange,
@@ -75,7 +86,6 @@ export function evaluateThermalComfort(input: {
   if (totalClo === undefined || !targetRange) return null;
 
   const [targetMin, targetMax] = targetRange;
-  const rangeWidth = Math.max(0.2, targetMax - targetMin);
 
   const localDeficit = Math.max(maxRegionalDeficit, maxExtremityDeficit);
   const localThreshold = maxRegionalDeficit >= maxExtremityDeficit
@@ -84,7 +94,7 @@ export function evaluateThermalComfort(input: {
   if (localDeficit > localThreshold) {
     return {
       riskType: "cold",
-      severity: localDeficit <= rangeWidth ? "moderate" : "high",
+      severity: getSeverity(localDeficit, targetRange),
       delta: localDeficit,
     };
   }
@@ -93,7 +103,7 @@ export function evaluateThermalComfort(input: {
     const deficit = targetMin - totalClo;
     return {
       riskType: "cold",
-      severity: deficit <= rangeWidth ? "moderate" : "high",
+      severity: getSeverity(deficit, targetRange),
       delta: deficit,
     };
   }
@@ -102,7 +112,7 @@ export function evaluateThermalComfort(input: {
     const excess = totalClo - targetMax;
     return {
       riskType: "overheat",
-      severity: excess <= rangeWidth ? "moderate" : "high",
+      severity: getSeverity(excess, targetRange),
       delta: excess,
     };
   }
@@ -114,15 +124,59 @@ export function evaluateThermalComfort(input: {
   };
 }
 
-export function calculateThermalComfortScore(input: {
-  totalClo: number | undefined;
-  targetRange: [number, number] | undefined;
-  maxRegionalDeficit?: number;
-  maxExtremityDeficit?: number;
-  regionalDeficitThreshold?: number;
-  extremityDeficitThreshold?: number;
-  overheatBufferClo?: number;
-}): number | null {
+export function evaluateThermalComfort(input: ThermalComfortInput): ThermalComfortDecision | null {
+  const {
+    totalClo,
+    targetRange,
+    maxRegionalDeficit = 0,
+    maxExtremityDeficit = 0,
+    overheatBufferClo = OVERHEAT_BUFFER_CLO,
+  } = input;
+
+  if (totalClo === undefined || !targetRange) return null;
+
+  const [targetMin, targetMax] = targetRange;
+  const localDeficit = Math.max(maxRegionalDeficit, maxExtremityDeficit);
+  const wholeBodyDeficit = targetMin - totalClo;
+  const wholeBodyExcess = totalClo - targetMax;
+
+  if (wholeBodyDeficit > THERMAL_DISPLAY_CLO_EPSILON) {
+    const delta = Math.max(
+      wholeBodyDeficit,
+      localDeficit > THERMAL_DISPLAY_CLO_EPSILON ? localDeficit : 0
+    );
+
+    return {
+      riskType: "cold",
+      severity: getSeverity(delta, targetRange),
+      delta,
+    };
+  }
+
+  if (wholeBodyExcess > overheatBufferClo + THERMAL_DISPLAY_CLO_EPSILON) {
+    return {
+      riskType: "overheat",
+      severity: getSeverity(wholeBodyExcess, targetRange),
+      delta: wholeBodyExcess,
+    };
+  }
+
+  if (localDeficit > THERMAL_DISPLAY_CLO_EPSILON) {
+    return {
+      riskType: "cold",
+      severity: getSeverity(localDeficit, targetRange),
+      delta: localDeficit,
+    };
+  }
+
+  return {
+    riskType: "comfortable",
+    severity: "moderate",
+    delta: 0,
+  };
+}
+
+export function calculateThermalComfortScore(input: ThermalComfortInput): number | null {
   const {
     totalClo,
     targetRange,
@@ -135,7 +189,7 @@ export function calculateThermalComfortScore(input: {
 
   if (totalClo === undefined || !targetRange) return null;
 
-  const decision = evaluateThermalComfort({
+  const decision = evaluateThermalComfortScoreState({
     totalClo,
     targetRange,
     maxRegionalDeficit,


### PR DESCRIPTION
## Summary
- separate display warning state from score penalties in thermal comfort logic
- only show cold warnings when whole-body clo is outside the visible target band or a body part is visibly below target
- apply the same logic to climb/descent risk cards and refresh the related regression tests

## Test plan
- [x] npx vitest run src/lib/biophysics/comfort.test.ts src/components/LayerDisplay.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermal comfort assessment logic to better evaluate body-part-specific cold stress alongside whole-body conditions.
  * Refined cold risk detection thresholds for more accurate warnings.
  * Updated cold stress explanation to clarify that warnings trigger when body parts fall below target thermal levels.

* **Tests**
  * Added comprehensive test coverage for thermal comfort evaluation scenarios, including tolerance conditions and overheat prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->