### PR TITLE
Restore overheat trigger at buffer boundary

### DIFF
--- a/src/lib/biophysics/comfort.test.ts
+++ b/src/lib/biophysics/comfort.test.ts
@@ -52,6 +52,18 @@ describe("evaluateThermalComfort", () => {
     expect(result?.riskType).toBe("overheat");
     expect(result?.delta).toBeCloseTo(0.4, 5);
   });
+
+  it("flags overheating immediately above the configured overheat buffer", () => {
+    const result = evaluateThermalComfort({
+      totalClo: 2.21,
+      targetRange: [1.5, 1.9],
+      maxRegionalDeficit: 0.02,
+      maxExtremityDeficit: 0.06,
+    });
+
+    expect(result?.riskType).toBe("overheat");
+    expect(result?.delta).toBeCloseTo(0.31, 5);
+  });
 });
 
 describe("calculateThermalComfortScore", () => {

--- a/src/lib/biophysics/comfort.ts
+++ b/src/lib/biophysics/comfort.ts
@@ -153,7 +153,7 @@ export function evaluateThermalComfort(input: ThermalComfortInput): ThermalComfo
     };
   }
 
-  if (wholeBodyExcess > overheatBufferClo + THERMAL_DISPLAY_CLO_EPSILON) {
+  if (wholeBodyExcess > overheatBufferClo) {
     return {
       riskType: "overheat",
       severity: getSeverity(wholeBodyExcess, targetRange),


### PR DESCRIPTION
## Summary
- restore the overheat UI trigger to the original `targetMax + overheatBufferClo` boundary
- keep the cold-display epsilon only for under-insulation and body-part deficit handling
- add a regression test covering the `(+0.30, +0.35]` overheat band

## Test Plan

- [x] CI=1 npx vitest run src/lib/biophysics/comfort.test.ts src/components/LayerDisplay.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted thermal overheat detection to trigger more promptly when insulation levels exceed acceptable ranges, improving early warning capabilities

* **Tests**
  * Added test case validating overheat detection with specific insulation parameters and deficit thresholds to verify accurate thermal stress identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->