### PR TITLE
Replace bottom-nav FAB with on-page Gear Up button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
+import { Loader2, Zap } from "lucide-react";
 import PageLayout from "@/components/PageLayout";
 import ActivitySelection from "@/components/ActivitySelection";
 import LayerDisplay from "@/components/LayerDisplay";
@@ -38,12 +39,20 @@ const HomeContent = () => {
     multiDayPlan,
     locationSearch,
     handleGoNow,
+    handleSubmit,
     handleWeatherChange,
     handleActivityChange,
     resetToInitialState,
   } = useGearUp();
 
   const { itemMappings } = useItemMappings();
+
+  const ActivityIcon = ACTIVITIES.find((item) => item.value === activity)?.icon ?? Zap;
+  const showGearUpButton =
+    !showResults &&
+    !activityInitializing &&
+    inputMode !== "planAhead" &&
+    !(inputMode === "manual" && locationDenied);
 
   return (
     <PageLayout onLogoClick={resetToInitialState} chromeVariant="compact">
@@ -119,6 +128,18 @@ const HomeContent = () => {
                 onDismiss={locationSearch.dismiss}
               />
             ) : null}
+            {showGearUpButton && (
+              <button
+                type="button"
+                aria-label="Gear Up"
+                onClick={() => void handleSubmit()}
+                disabled={loading}
+                className="inline-flex h-12 w-full max-w-[420px] items-center justify-center gap-2 rounded-xl border border-white/10 bg-[linear-gradient(180deg,#111827_0%,#020617_100%)] px-6 text-sm font-semibold text-white shadow-[0_14px_26px_rgba(0,0,0,0.44)] transition-transform duration-200 hover:bg-[#030712] disabled:opacity-70"
+              >
+                {loading ? <Loader2 className="size-5 animate-spin" /> : <ActivityIcon className="size-5" />}
+                <span className="tracking-wide">Gear Up</span>
+              </button>
+            )}
           </>
         ) : inputMode === "planAhead" && multiDayPlan ? (
           <MultiDayPlanDisplay

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,11 +48,7 @@ const HomeContent = () => {
   const { itemMappings } = useItemMappings();
 
   const ActivityIcon = ACTIVITIES.find((item) => item.value === activity)?.icon ?? Zap;
-  const showGearUpButton =
-    !showResults &&
-    !activityInitializing &&
-    inputMode !== "planAhead" &&
-    !(inputMode === "manual" && locationDenied);
+  const showGearUpButton = !showResults && inputMode !== "planAhead";
 
   return (
     <PageLayout onLogoClick={resetToInitialState} chromeVariant="compact">

--- a/src/components/AppNavigation.test.tsx
+++ b/src/components/AppNavigation.test.tsx
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MobileTabBar, DesktopActionDock } from "./AppNavigation";
 
-// ── Mocks ────────────────────────────────────────────────────────────
 let mockPathname = "/";
 const mockPush = vi.fn();
 
@@ -20,8 +19,6 @@ const localStorageMock = {
 };
 Object.defineProperty(window, "localStorage", { value: localStorageMock });
 
-// ── Helpers ──────────────────────────────────────────────────────────
-/** Renders both nav bars together, same as PageLayout does. */
 function renderBothNavs() {
   return render(
     <>
@@ -31,162 +28,27 @@ function renderBothNavs() {
   );
 }
 
-function getMobileGearUp() {
-  return screen.getByRole("button", { name: /gear up/i });
-}
-
-function getDesktopGearUp() {
-  return screen.getByRole("button", { name: /start recommendation/i });
-}
-
-// ── Tests ────────────────────────────────────────────────────────────
-describe("AppNavigation — desktop ↔ mobile state", () => {
-  let originalGeolocation: Geolocation;
-
+describe("AppNavigation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPathname = "/";
     localStorageMock.getItem.mockReturnValue(null);
-    originalGeolocation = navigator.geolocation;
   });
 
-  afterEach(() => {
-    Object.defineProperty(navigator, "geolocation", {
-      value: originalGeolocation,
-      writable: true,
-      configurable: true,
-    });
-  });
-
-  // ── Both bars rendered simultaneously ────────────────────────────
-  describe("simultaneous rendering", () => {
-    it("renders both mobile and desktop Gear Up buttons", () => {
-      renderBothNavs();
-      expect(getMobileGearUp()).toBeInTheDocument();
-      expect(getDesktopGearUp()).toBeInTheDocument();
-    });
-
+  describe("rendering", () => {
     it("renders Plan and Wardrobe tabs in both navs", () => {
       renderBothNavs();
       expect(screen.getAllByText("Plan")).toHaveLength(2);
       expect(screen.getAllByText("Wardrobe")).toHaveLength(2);
     });
-  });
 
-  // ── Loading state syncs via gearUpLoading event ──────────────────
-  describe("loading state synchronisation", () => {
-    it("gearUpLoading event disables both Gear Up buttons", () => {
+    it("does not render a Gear Up button in either nav", () => {
       renderBothNavs();
-      expect(getMobileGearUp()).not.toBeDisabled();
-      expect(getDesktopGearUp()).not.toBeDisabled();
-
-      act(() => {
-        window.dispatchEvent(new CustomEvent("gearUpLoading", { detail: true }));
-      });
-
-      expect(getMobileGearUp()).toBeDisabled();
-      expect(getDesktopGearUp()).toBeDisabled();
-    });
-
-    it("gearUpLoading false re-enables both buttons", () => {
-      renderBothNavs();
-
-      act(() => {
-        window.dispatchEvent(new CustomEvent("gearUpLoading", { detail: true }));
-      });
-      expect(getMobileGearUp()).toBeDisabled();
-      expect(getDesktopGearUp()).toBeDisabled();
-
-      act(() => {
-        window.dispatchEvent(new CustomEvent("gearUpLoading", { detail: false }));
-      });
-      expect(getMobileGearUp()).not.toBeDisabled();
-      expect(getDesktopGearUp()).not.toBeDisabled();
+      expect(screen.queryByRole("button", { name: /gear up/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /start recommendation/i })).toBeNull();
     });
   });
 
-  // ── Activity change syncs via activityChange event ───────────────
-  describe("activity change synchronisation", () => {
-    it("activityChange event updates both navs without crashing", () => {
-      renderBothNavs();
-
-      act(() => {
-        window.dispatchEvent(
-          new CustomEvent("activityChange", { detail: { value: "xc_skiing" } })
-        );
-      });
-
-      // Both buttons still present after the icon swap
-      expect(getMobileGearUp()).toBeInTheDocument();
-      expect(getDesktopGearUp()).toBeInTheDocument();
-    });
-
-    it("multiple rapid activity changes leave both navs in sync", () => {
-      renderBothNavs();
-
-      act(() => {
-        window.dispatchEvent(
-          new CustomEvent("activityChange", { detail: { value: "running" } })
-        );
-        window.dispatchEvent(
-          new CustomEvent("activityChange", { detail: { value: "alpine_skiing" } })
-        );
-        window.dispatchEvent(
-          new CustomEvent("activityChange", { detail: { value: "biking" } })
-        );
-      });
-
-      expect(getMobileGearUp()).toBeInTheDocument();
-      expect(getDesktopGearUp()).toBeInTheDocument();
-    });
-  });
-
-  // ── Gear Up click parity ─────────────────────────────────────────
-  describe("Gear Up click parity", () => {
-    it("mobile button dispatches gearUp event on home page", async () => {
-      const spy = vi.fn();
-      window.addEventListener("gearUp", spy);
-
-      renderBothNavs();
-      await userEvent.setup().click(getMobileGearUp());
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      window.removeEventListener("gearUp", spy);
-    });
-
-    it("desktop button dispatches gearUp event on home page", async () => {
-      const spy = vi.fn();
-      window.addEventListener("gearUp", spy);
-
-      renderBothNavs();
-      await userEvent.setup().click(getDesktopGearUp());
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      window.removeEventListener("gearUp", spy);
-    });
-
-    it("both navigate to geoDenied when off home page without geolocation", async () => {
-      mockPathname = "/wardrobe";
-      Object.defineProperty(navigator, "geolocation", {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      });
-
-      const user = userEvent.setup();
-      renderBothNavs();
-
-      await user.click(getMobileGearUp());
-      expect(mockPush).toHaveBeenCalledWith("/?gearUp=1&geoDenied=1");
-
-      mockPush.mockClear();
-
-      await user.click(getDesktopGearUp());
-      expect(mockPush).toHaveBeenCalledWith("/?gearUp=1&geoDenied=1");
-    });
-  });
-
-  // ── Plan tab parity ──────────────────────────────────────────────
   describe("Plan tab parity", () => {
     it("both Plan tabs dispatch navigatePlanAhead on home page", async () => {
       const spy = vi.fn();
@@ -221,59 +83,6 @@ describe("AppNavigation — desktop ↔ mobile state", () => {
       expect(mockPush).toHaveBeenCalledWith("/?mode=planAhead");
 
       window.removeEventListener("navigatePlanAhead", spy);
-    });
-  });
-
-  // ── Interleaved events (simulating viewport switch mid-action) ───
-  describe("viewport switch mid-action", () => {
-    it("desktop Gear Up click then gearUpLoading syncs mobile state", async () => {
-      const user = userEvent.setup();
-      renderBothNavs();
-
-      // Click desktop Gear Up on home page — dispatches gearUp event
-      await user.click(getDesktopGearUp());
-
-      // useGearUp broadcasts loading (SUBMIT_START) — both navs pick it up
-      act(() => {
-        window.dispatchEvent(new CustomEvent("gearUpLoading", { detail: true }));
-      });
-
-      // User shrinks viewport: mobile FAB should also show loading
-      expect(getMobileGearUp()).toBeDisabled();
-      expect(getDesktopGearUp()).toBeDisabled();
-
-      // Loading completes (SUBMIT_SUCCESS)
-      act(() => {
-        window.dispatchEvent(new CustomEvent("gearUpLoading", { detail: false }));
-      });
-
-      expect(getMobileGearUp()).not.toBeDisabled();
-      expect(getDesktopGearUp()).not.toBeDisabled();
-    });
-
-    it("activity changed then loading fired — both navs stay consistent", async () => {
-      renderBothNavs();
-
-      act(() => {
-        window.dispatchEvent(
-          new CustomEvent("activityChange", { detail: { value: "backcountry_skiing" } })
-        );
-      });
-
-      act(() => {
-        window.dispatchEvent(new CustomEvent("gearUpLoading", { detail: true }));
-      });
-
-      // Both buttons disabled with the new activity icon
-      expect(getMobileGearUp()).toBeDisabled();
-      expect(getDesktopGearUp()).toBeDisabled();
-
-      act(() => {
-        window.dispatchEvent(new CustomEvent("gearUpLoading", { detail: false }));
-      });
-
-      expect(getMobileGearUp()).not.toBeDisabled();
-      expect(getDesktopGearUp()).not.toBeDisabled();
     });
   });
 });

--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { CalendarDays, Shirt, Zap, Loader2 } from "lucide-react";
+import { CalendarDays, Shirt } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { ACTIVITIES, DEFAULT_ACTIVITY } from "@/data/activities";
-import { STORAGE_KEYS } from "@/lib/storage";
 import { useNativeTabShell } from "@/hooks/useNativeTabShell";
 
 const TAB_ITEMS = [
@@ -21,64 +19,7 @@ interface RouterLike {
 }
 
 function useNavigationState(pathname: string, router: RouterLike) {
-  const [isGearUpLoading, setIsGearUpLoading] = useState(false);
-  const [activityValue, setActivityValue] = useState<string>("");
-  const [isFabPulse, setIsFabPulse] = useState(false);
-  const pulseTimeoutRef = useRef<number | null>(null);
-
   const isLandingScreen = pathname === "/";
-
-  useEffect(() => {
-    const onLoading = (event: Event) => {
-      const detail = (event as CustomEvent<boolean>).detail;
-      setIsGearUpLoading(Boolean(detail));
-    };
-    window.addEventListener("gearUpLoading", onLoading);
-    return () => window.removeEventListener("gearUpLoading", onLoading);
-  }, []);
-
-  useEffect(() => {
-    if (pathname !== "/" && isGearUpLoading) {
-      setIsGearUpLoading(false);
-    }
-  }, [pathname, isGearUpLoading]);
-
-  useEffect(() => {
-    if (activityValue) return;
-    const stored = typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEYS.LAST_ACTIVITY) : null;
-    if (stored) {
-      setActivityValue(stored);
-      return;
-    }
-    setActivityValue(DEFAULT_ACTIVITY);
-  }, [activityValue]);
-
-  useEffect(() => {
-    const onActivityChange = (event: Event) => {
-      const detail = (event as CustomEvent<{ name?: string; value?: string }>).detail;
-      const nextValue = detail?.value ?? "";
-      setActivityValue(nextValue);
-      setIsFabPulse(true);
-      if (pulseTimeoutRef.current !== null) {
-        window.clearTimeout(pulseTimeoutRef.current);
-      }
-      pulseTimeoutRef.current = window.setTimeout(() => {
-        setIsFabPulse(false);
-      }, 180);
-    };
-    window.addEventListener("activityChange", onActivityChange);
-    return () => {
-      window.removeEventListener("activityChange", onActivityChange);
-      if (pulseTimeoutRef.current !== null) {
-        window.clearTimeout(pulseTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const ActivityGlyph = useMemo(() => {
-    const match = ACTIVITIES.find((item) => item.value === activityValue);
-    return match?.icon ?? Zap;
-  }, [activityValue]);
 
   const isTabActive = useCallback(
     (href: string) => (href.startsWith("/?") ? pathname === "/" : pathname === href),
@@ -98,43 +39,10 @@ function useNavigationState(pathname: string, router: RouterLike) {
     [pathname, router]
   );
 
-  const onGearUpClick = useCallback(() => {
-    if (isGearUpLoading) return;
-    if (pathname === "/") {
-      window.dispatchEvent(new CustomEvent("gearUp"));
-      return;
-    }
-    if (!navigator.geolocation) {
-      router.push("/?gearUp=1&geoDenied=1");
-      return;
-    }
-    setIsGearUpLoading(true);
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        sessionStorage.setItem(
-          "swttr-gearup-coords",
-          JSON.stringify({
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-          })
-        );
-        router.push("/?gearUp=1");
-      },
-      () => {
-        sessionStorage.removeItem("swttr-gearup-coords");
-        router.push("/?gearUp=1&geoDenied=1");
-      }
-    );
-  }, [isGearUpLoading, pathname, router]);
-
   return {
-    ActivityGlyph,
     isLandingScreen,
-    isGearUpLoading,
-    isFabPulse,
     isTabActive,
     onTabClick,
-    onGearUpClick,
   };
 }
 
@@ -142,17 +50,9 @@ export function MobileTabBar() {
   const isNativeTabShell = useNativeTabShell();
   const pathname = usePathname();
   const router = useRouter();
-  const {
-    ActivityGlyph,
-    isLandingScreen,
-    isGearUpLoading,
-    isFabPulse,
-    isTabActive,
-    onTabClick,
-    onGearUpClick,
-  } = useNavigationState(pathname, router);
+  const { isLandingScreen, isTabActive, onTabClick } = useNavigationState(pathname, router);
 
-  const renderTab = (item: { href: string; label: string; icon: typeof CalendarDays }) => {
+  const renderTab = (item: TabItem) => {
     const isActive = isTabActive(item.href);
 
     return (
@@ -194,22 +94,9 @@ export function MobileTabBar() {
         isLandingScreen ? "text-white/60" : "text-white/80"
       )}
     >
-      <div className="h-[74px] border-t border-white/20 bg-[rgba(17,45,62,0.74)] backdrop-blur-2xl">
-        <div className="flex h-full items-center justify-around gap-3 px-3 pb-1 pt-1.5">
+      <div className="h-[64px] border-t border-white/20 bg-[rgba(17,45,62,0.74)] backdrop-blur-2xl">
+        <div className="flex h-full items-center justify-around px-6 pb-1 pt-1.5">
           {renderTab(TAB_ITEMS[0])}
-          <button
-            type="button"
-            aria-label="Gear Up"
-            onClick={onGearUpClick}
-            disabled={isGearUpLoading}
-            className={cn(
-              "inline-flex h-12 min-w-[140px] flex-shrink items-center justify-center gap-2 rounded-xl border border-white/10 bg-[linear-gradient(180deg,#111827_0%,#020617_100%)] px-5 text-sm font-semibold text-white shadow-[0_14px_26px_rgba(0,0,0,0.44)] transition-transform duration-200 hover:bg-[#030712]",
-              isFabPulse && "scale-[1.03]"
-            )}
-          >
-            {isGearUpLoading ? <Loader2 className="size-5 animate-spin" /> : <ActivityGlyph className="size-5" />}
-            <span className="tracking-wide">Gear Up</span>
-          </button>
           {renderTab(TAB_ITEMS[1])}
         </div>
       </div>
@@ -221,15 +108,7 @@ export function DesktopActionDock() {
   const isNativeTabShell = useNativeTabShell();
   const pathname = usePathname();
   const router = useRouter();
-  const {
-    ActivityGlyph,
-    isLandingScreen,
-    isGearUpLoading,
-    isFabPulse,
-    isTabActive,
-    onTabClick,
-    onGearUpClick,
-  } = useNavigationState(pathname, router);
+  const { isLandingScreen, isTabActive, onTabClick } = useNavigationState(pathname, router);
 
   const renderDesktopTab = (item: TabItem) => {
     const isActive = isTabActive(item.href);
@@ -267,19 +146,6 @@ export function DesktopActionDock() {
     >
       <div className="pointer-events-auto inline-flex max-w-[min(640px,calc(100vw-var(--sidebar-width)-2.25rem))] items-center gap-2 rounded-2xl border border-white/25 bg-[linear-gradient(135deg,rgba(54,86,116,0.8)_0%,rgba(38,86,108,0.78)_100%)] p-2 shadow-[0_18px_34px_rgba(0,0,0,0.3)] backdrop-blur-xl">
         {renderDesktopTab(TAB_ITEMS[0])}
-        <button
-          type="button"
-          aria-label="Start recommendation"
-          onClick={onGearUpClick}
-          disabled={isGearUpLoading}
-          className={cn(
-            "inline-flex h-12 min-w-[220px] items-center justify-center gap-2 rounded-xl border border-white/10 bg-[linear-gradient(180deg,#111827_0%,#020617_100%)] px-6 text-sm font-semibold text-white shadow-[0_14px_26px_rgba(0,0,0,0.44)] transition-transform duration-200 hover:bg-[#030712]",
-            isFabPulse && "scale-[1.03]"
-          )}
-        >
-          {isGearUpLoading ? <Loader2 className="size-5 animate-spin" /> : <ActivityGlyph className="size-5" />}
-          <span className="tracking-wide">Gear Up</span>
-        </button>
         {renderDesktopTab(TAB_ITEMS[1])}
       </div>
     </nav>

--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -194,28 +194,24 @@ export function MobileTabBar() {
         isLandingScreen ? "text-white/60" : "text-white/80"
       )}
     >
-      <div className="relative h-[74px] border-t border-white/20 bg-[rgba(17,45,62,0.74)] backdrop-blur-2xl">
-        <div className="flex h-full items-center justify-around px-3 pb-1 pt-1.5">
+      <div className="h-[74px] border-t border-white/20 bg-[rgba(17,45,62,0.74)] backdrop-blur-2xl">
+        <div className="flex h-full items-center justify-around gap-3 px-3 pb-1 pt-1.5">
           {renderTab(TAB_ITEMS[0])}
-          <div className="w-16" />
+          <button
+            type="button"
+            aria-label="Gear Up"
+            onClick={onGearUpClick}
+            disabled={isGearUpLoading}
+            className={cn(
+              "inline-flex h-12 min-w-[140px] flex-shrink items-center justify-center gap-2 rounded-xl border border-white/10 bg-[linear-gradient(180deg,#111827_0%,#020617_100%)] px-5 text-sm font-semibold text-white shadow-[0_14px_26px_rgba(0,0,0,0.44)] transition-transform duration-200 hover:bg-[#030712]",
+              isFabPulse && "scale-[1.03]"
+            )}
+          >
+            {isGearUpLoading ? <Loader2 className="size-5 animate-spin" /> : <ActivityGlyph className="size-5" />}
+            <span className="tracking-wide">Gear Up</span>
+          </button>
           {renderTab(TAB_ITEMS[1])}
         </div>
-
-        <button
-          type="button"
-          className={cn(
-            "absolute left-1/2 top-0 flex h-[60px] w-[60px] -translate-x-1/2 -translate-y-[56%] items-center justify-center rounded-full border border-white/25 bg-[radial-gradient(circle_at_30%_20%,rgba(255,255,255,0.16)_0%,rgba(255,255,255,0.04)_28%,rgba(5,10,20,0.92)_100%)] text-white shadow-[0_16px_28px_rgba(0,0,0,0.42)] transition-transform duration-200",
-            isFabPulse && "scale-110"
-          )}
-          aria-label="Gear Up"
-          onClick={onGearUpClick}
-          disabled={isGearUpLoading}
-        >
-          {isGearUpLoading ? <Loader2 className="size-6 animate-spin" /> : <ActivityGlyph className="size-6" />}
-        </button>
-        <span className="pointer-events-none absolute left-1/2 top-8 -translate-x-1/2 text-[11px] font-semibold tracking-[0.01em] text-white">
-          Gear Up
-        </span>
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- Removes the circular FAB and Gear Up button from the bottom navigation entirely (mobile and desktop). Bottom nav is now just Plan + Wardrobe.
- Adds a black-gradient Gear Up button (activity icon + text, full-width up to 420px) directly on the home page, below the activity selector — only shown in the default form view.
- Wires the new button to `handleSubmit` directly. Shows a spinner while loading.

## Behavior change
- The previous bottom-nav button worked from any page (including `/wardrobe`) and pre-fetched geolocation before navigating home. With Gear Up living on the home page, that cross-page shortcut goes away — users on other pages tap Plan to return home, then Gear Up.

## Test plan
- [x] `npm test src/components/AppNavigation.test.tsx` (4/4 passing — Plan tab parity + no-Gear-Up-in-nav)
- [x] Visual check at ~390px: button appears under the effort card, not in the bottom nav
- [x] Tap Gear Up → recommendation flow runs
- [x] Plan-ahead and manual-location modes hide the button (their own forms have submit actions)