### PR TITLE
Add Trips/Crew feature (Flow BE)

### DIFF
--- a/src/app/api/packing-list/route.ts
+++ b/src/app/api/packing-list/route.ts
@@ -2,62 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { getAuthUserId } from "@/lib/auth";
 import { buildPackingListFromDays } from "@/lib/packingList";
+import { fetchUserWardrobeItems } from "@/lib/userWardrobe";
 import type { DailyLayerPlan } from "@/types/plan";
 import type { WardrobeItem } from "@/types/wardrobe";
-
-async function fetchUserWardrobeItems(userId: string): Promise<WardrobeItem[]> {
-  const supabase = getSupabase();
-  if (!supabase) return [];
-
-  const { data: wardrobeEntries, error } = await supabase
-    .from("user_wardrobe")
-    .select("*")
-    .eq("user_id", userId)
-    .order("created_at", { ascending: false });
-
-  if (error || !wardrobeEntries) return [];
-
-  const itemsWithDetails = await Promise.all(
-    wardrobeEntries.map(async (entry) => {
-      let itemDetails = null;
-
-      if (entry.item_type === "garment") {
-        const { data } = await supabase
-          .from("garments")
-          .select("*, garment_thermal_properties(*)")
-          .eq("id", entry.item_id)
-          .single();
-        itemDetails = data;
-      } else if (entry.item_type === "handwear") {
-        const { data } = await supabase
-          .from("handwear")
-          .select("*")
-          .eq("id", entry.item_id)
-          .single();
-        itemDetails = data;
-      } else if (entry.item_type === "headwear") {
-        const { data } = await supabase
-          .from("headwear")
-          .select("*")
-          .eq("id", entry.item_id)
-          .single();
-        itemDetails = data;
-      }
-
-      return {
-        id: entry.id,
-        item_type: entry.item_type,
-        item_id: entry.item_id,
-        nickname: entry.nickname,
-        disabled: entry.disabled ?? false,
-        created_at: entry.created_at,
-        details: itemDetails,
-      };
-    })
-  );
-
-  return itemsWithDetails;
-}
 
 export async function POST(request: NextRequest) {
   let body: {
@@ -90,8 +37,9 @@ export async function POST(request: NextRequest) {
   let wardrobeItems: WardrobeItem[] = [];
   try {
     const userId = await getAuthUserId();
-    if (userId) {
-      wardrobeItems = await fetchUserWardrobeItems(userId);
+    const supabase = getSupabase();
+    if (userId && supabase) {
+      wardrobeItems = await fetchUserWardrobeItems(supabase, userId);
     }
   } catch {
     // Continue without wardrobe data

--- a/src/app/api/v1/trips/[id]/days/[date]/kits/[memberId]/route.ts
+++ b/src/app/api/v1/trips/[id]/days/[date]/kits/[memberId]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip } from "@/lib/trips";
+import type { TripEffort, TripKitState } from "@/types/trips";
+
+type RouteContext = { params: Promise<{ id: string; date: string; memberId: string }> };
+
+export async function PUT(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id, date, memberId } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const { items, effort, note, state } = (body ?? {}) as {
+    items?: string[];
+    effort?: TripEffort;
+    note?: string | null;
+    state?: TripKitState;
+  };
+
+  const { data: day } = await supabase
+    .from("trip_days")
+    .select("id")
+    .eq("trip_id", id)
+    .eq("date", date)
+    .maybeSingle();
+  if (!day) return NextResponse.json({ error: "Day not found" }, { status: 404 });
+
+  const { data, error } = await supabase
+    .from("trip_member_day_kits")
+    .upsert(
+      {
+        trip_day_id: day.id,
+        trip_member_id: memberId,
+        items: items ?? [],
+        effort: effort ?? "steady",
+        note: note ?? null,
+        state: state ?? "ok",
+      },
+      { onConflict: "trip_day_id,trip_member_id" }
+    )
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ kit: data });
+}

--- a/src/app/api/v1/trips/[id]/days/[date]/route.ts
+++ b/src/app/api/v1/trips/[id]/days/[date]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip } from "@/lib/trips";
+
+type RouteContext = { params: Promise<{ id: string; date: string }> };
+
+export async function PATCH(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id, date } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const update: Record<string, unknown> = {};
+  if (body?.stop_id !== undefined) update.stop_id = body.stop_id;
+  if (typeof body?.activity === "string" || body?.activity === null)
+    update.activity = body.activity;
+
+  const { data, error } = await supabase
+    .from("trip_days")
+    .update(update)
+    .eq("trip_id", id)
+    .eq("date", date)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ day: data });
+}

--- a/src/app/api/v1/trips/[id]/gear/[gearId]/route.ts
+++ b/src/app/api/v1/trips/[id]/gear/[gearId]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip } from "@/lib/trips";
+
+type RouteContext = { params: Promise<{ id: string; gearId: string }> };
+
+export async function PATCH(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id, gearId } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const update: Record<string, unknown> = {};
+  if (typeof body?.description === "string") update.description = body.description;
+  if (body?.assignee_member_id !== undefined)
+    update.assignee_member_id = body.assignee_member_id;
+
+  const { data, error } = await supabase
+    .from("trip_group_gear")
+    .update(update)
+    .eq("id", gearId)
+    .eq("trip_id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ gear: data });
+}
+
+export async function DELETE(_request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id, gearId } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { error } = await supabase
+    .from("trip_group_gear")
+    .delete()
+    .eq("id", gearId)
+    .eq("trip_id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/trips/[id]/gear/route.ts
+++ b/src/app/api/v1/trips/[id]/gear/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip } from "@/lib/trips";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const { description, assignee_member_id } = (body ?? {}) as {
+    description?: string;
+    assignee_member_id?: string | null;
+  };
+  if (!description)
+    return NextResponse.json({ error: "description required" }, { status: 400 });
+
+  const { data: existing } = await supabase
+    .from("trip_group_gear")
+    .select("sort_order")
+    .eq("trip_id", id)
+    .order("sort_order", { ascending: false })
+    .limit(1);
+  const nextSort = ((existing?.[0]?.sort_order as number | undefined) ?? -1) + 1;
+
+  const { data, error } = await supabase
+    .from("trip_group_gear")
+    .insert({
+      trip_id: id,
+      description,
+      assignee_member_id: assignee_member_id ?? null,
+      sort_order: nextSort,
+    })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ gear: data }, { status: 201 });
+}

--- a/src/app/api/v1/trips/[id]/members/[memberId]/route.ts
+++ b/src/app/api/v1/trips/[id]/members/[memberId]/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip } from "@/lib/trips";
+
+type RouteContext = { params: Promise<{ id: string; memberId: string }> };
+
+export async function PATCH(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id, memberId } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const update: Record<string, unknown> = {};
+  if (typeof body?.display_name === "string") update.display_name = body.display_name;
+  if (typeof body?.role === "string") update.role = body.role;
+  if (typeof body?.status === "string") update.status = body.status;
+
+  const { data, error } = await supabase
+    .from("trip_members")
+    .update(update)
+    .eq("id", memberId)
+    .eq("trip_id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ member: data });
+}
+
+export async function DELETE(_request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id, memberId } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (access.owner_user_id !== userId)
+    return NextResponse.json({ error: "Organizer only" }, { status: 403 });
+
+  const { data: target } = await supabase
+    .from("trip_members")
+    .select("role")
+    .eq("id", memberId)
+    .eq("trip_id", id)
+    .maybeSingle();
+  if (target?.role === "organizer")
+    return NextResponse.json({ error: "Cannot remove organizer" }, { status: 400 });
+
+  const { error } = await supabase
+    .from("trip_members")
+    .delete()
+    .eq("id", memberId)
+    .eq("trip_id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Unassign any group gear held by this member.
+  await supabase
+    .from("trip_group_gear")
+    .update({ assignee_member_id: null })
+    .eq("trip_id", id)
+    .eq("assignee_member_id", memberId);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/trips/[id]/members/route.ts
+++ b/src/app/api/v1/trips/[id]/members/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip, generateInviteToken } from "@/lib/trips";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const { display_name, kind } = (body ?? {}) as {
+    display_name?: string;
+    kind?: "invite" | "guest";
+  };
+  if (!display_name || !kind)
+    return NextResponse.json(
+      { error: "display_name and kind required" },
+      { status: 400 }
+    );
+
+  const row =
+    kind === "guest"
+      ? {
+          trip_id: id,
+          user_id: null,
+          display_name,
+          role: "guest" as const,
+          status: "guest" as const,
+        }
+      : {
+          trip_id: id,
+          user_id: null,
+          display_name,
+          role: "member" as const,
+          status: "invited" as const,
+          invite_token: generateInviteToken(),
+        };
+
+  const { data, error } = await supabase
+    .from("trip_members")
+    .insert(row)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ member: data }, { status: 201 });
+}

--- a/src/app/api/v1/trips/[id]/pack/route.ts
+++ b/src/app/api/v1/trips/[id]/pack/route.ts
@@ -1,0 +1,211 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip, loadTripFull } from "@/lib/trips";
+import { buildMultiDayLayerPlan } from "@/lib/planAhead";
+import { buildPackingListFromDays } from "@/lib/packingList";
+import { fetchUserWardrobeItems } from "@/lib/userWardrobe";
+import { getAdjustedTempRange } from "@/lib/getTempRange";
+import { convertLegacyRecommendation, type LegacyRecommendation } from "@/lib/layers";
+import { tripActivityToRecommendationKey } from "@/lib/trip-activities";
+import layerRecommendations from "@/data/layerRecommendations.json";
+import type { ForecastHour, DailyLayerPlan } from "@/types/plan";
+import type { Recommendation } from "@/types/recommendations";
+import type { TemperatureSensitivity } from "@/types/preferences";
+import type { TripDay, TripStop } from "@/types/trips";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+function makeRecommendationFor(activity: string, sensitivity: TemperatureSensitivity) {
+  return (effectiveTemp: number): Recommendation | null => {
+    const range = getAdjustedTempRange(effectiveTemp, sensitivity);
+    const activityData = layerRecommendations[activity as keyof typeof layerRecommendations];
+    if (!activityData) return null;
+    const legacy = activityData[range as keyof typeof activityData];
+    if (!legacy) return null;
+    return convertLegacyRecommendation(legacy as LegacyRecommendation);
+  };
+}
+
+async function fetchHourly(
+  lat: number,
+  lon: number,
+  startDate: string,
+  endDate: string
+): Promise<ForecastHour[]> {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&hourly=temperature_2m,wind_speed_10m,precipitation_probability&start_date=${startDate}&end_date=${endDate}&temperature_unit=fahrenheit&wind_speed_unit=mph`;
+  const res = await fetch(url);
+  if (!res.ok) return [];
+  const data = await res.json();
+  const time: string[] = Array.isArray(data?.hourly?.time) ? data.hourly.time : [];
+  const temp: number[] = Array.isArray(data?.hourly?.temperature_2m) ? data.hourly.temperature_2m : [];
+  const wind: number[] = Array.isArray(data?.hourly?.wind_speed_10m) ? data.hourly.wind_speed_10m : [];
+  const precip: number[] = Array.isArray(data?.hourly?.precipitation_probability) ? data.hourly.precipitation_probability : [];
+  return time
+    .map((t, i) => ({
+      time: t,
+      temperature: Math.round(Number(temp[i] ?? 0)),
+      windSpeed: Math.round(Number(wind[i] ?? 0)),
+      precipitationProbability: Math.round(Number(precip[i] ?? 0)),
+    }))
+    .filter(
+      (h) =>
+        typeof h.time === "string" &&
+        Number.isFinite(h.temperature) &&
+        Number.isFinite(h.windSpeed) &&
+        Number.isFinite(h.precipitationProbability)
+    );
+}
+
+function chooseStop(day: TripDay, stops: TripStop[]): TripStop | undefined {
+  if (day.stop_id) {
+    const found = stops.find((s) => s.id === day.stop_id);
+    if (found) return found;
+  }
+  return stops[0];
+}
+
+function chooseActivity(day: TripDay, stop: TripStop | undefined): string | null {
+  if (day.activity) return day.activity;
+  if (stop && stop.activities.length > 0) return stop.activities[0];
+  return null;
+}
+
+export async function GET(_request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const full = await loadTripFull(supabase, id);
+  if (!full) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  // Read sensitivity preference if it exists (best-effort).
+  let sensitivity: TemperatureSensitivity = "neutral";
+  try {
+    const { data: prefs } = await supabase
+      .from("user_preferences")
+      .select("sensitivity")
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (prefs?.sensitivity === "hot" || prefs?.sensitivity === "cold") {
+      sensitivity = prefs.sensitivity;
+    }
+  } catch {
+    // Table may not exist in this project — fall back to neutral.
+  }
+
+  // Group days by (stopId, activityKey) so we can issue one weather fetch per
+  // location-range and call the recommendation engine once per group.
+  const groups = new Map<
+    string,
+    { stop: TripStop; activityKey: string; days: TripDay[] }
+  >();
+  const skipped: { date: string; reason: string }[] = [];
+  for (const day of full.days) {
+    const stop = chooseStop(day, full.stops);
+    const activity = chooseActivity(day, stop);
+    if (!stop) {
+      skipped.push({ date: day.date, reason: "no_stop" });
+      continue;
+    }
+    if (!stop.latitude || !stop.longitude) {
+      skipped.push({ date: day.date, reason: "no_coords" });
+      continue;
+    }
+    if (!activity) {
+      skipped.push({ date: day.date, reason: "no_activity" });
+      continue;
+    }
+    const activityKey = tripActivityToRecommendationKey(activity);
+    if (!activityKey) {
+      skipped.push({ date: day.date, reason: "activity_unsupported" });
+      continue;
+    }
+    const groupKey = `${stop.id}:${activityKey}`;
+    const existing = groups.get(groupKey);
+    if (existing) {
+      existing.days.push(day);
+    } else {
+      groups.set(groupKey, { stop, activityKey, days: [day] });
+    }
+  }
+
+  const dailyPlans: DailyLayerPlan[] = [];
+  for (const group of groups.values()) {
+    const dates = group.days.map((d) => d.date).sort();
+    const startDate = dates[0];
+    const endDate = dates[dates.length - 1];
+    const hourly = await fetchHourly(
+      Number(group.stop.latitude),
+      Number(group.stop.longitude),
+      startDate,
+      endDate
+    );
+    if (hourly.length === 0) continue;
+    const durationDays =
+      Math.round(
+        (new Date(`${endDate}T00:00:00Z`).getTime() -
+          new Date(`${startDate}T00:00:00Z`).getTime()) /
+          86400000
+      ) + 1;
+    const plan = buildMultiDayLayerPlan({
+      startDate: new Date(`${startDate}T00:00:00`),
+      durationDays,
+      hourlyForecast: hourly,
+      getRecommendation: makeRecommendationFor(group.activityKey, sensitivity),
+    });
+    const dayDateSet = new Set(group.days.map((d) => d.date));
+    for (const day of plan.days) {
+      // Only include days that actually belong to this group (the plan may
+      // include extra dates inside the start/end span that belong to other
+      // groups).
+      if (dayDateSet.has(day.date)) dailyPlans.push(day);
+    }
+  }
+
+  // Pull this user's item mappings + wardrobe so the engine can resolve
+  // standard layer slots to the specific gear they own.
+  const [mappingsRes, wardrobeItems] = await Promise.all([
+    supabase
+      .from("user_item_mappings")
+      .select("body_part, layer_type, standard_option, custom_name")
+      .eq("user_id", userId),
+    fetchUserWardrobeItems(supabase, userId),
+  ]);
+  const itemMappings = new Map<string, string>();
+  for (const row of mappingsRes.data ?? []) {
+    itemMappings.set(
+      `${row.body_part}:${row.layer_type}:${row.standard_option}`,
+      row.custom_name
+    );
+  }
+
+  const packingList = buildPackingListFromDays(dailyPlans, itemMappings, wardrobeItems);
+
+  // Find the requesting user's TripMember row and any group gear assigned to them.
+  const myMember = full.members.find((m) => m.user_id === userId);
+  const myGear = myMember
+    ? full.gear
+        .filter((g) => g.assignee_member_id === myMember.id)
+        .map((g) => g.description)
+    : [];
+
+  return NextResponse.json({
+    trip: {
+      id: full.trip.id,
+      name: full.trip.name,
+      start_date: full.trip.start_date,
+      end_date: full.trip.end_date,
+    },
+    coveredDays: dailyPlans.length,
+    totalDays: full.days.length,
+    skipped,
+    packingList,
+    groupGear: myGear,
+  });
+}

--- a/src/app/api/v1/trips/[id]/route.ts
+++ b/src/app/api/v1/trips/[id]/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import {
+  assertCanAccessTrip,
+  classifyTripStatus,
+  enumerateDates,
+  loadTripFull,
+} from "@/lib/trips";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const full = await loadTripFull(supabase, id);
+  if (!full) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  return NextResponse.json(full);
+}
+
+export async function PATCH(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (access.owner_user_id !== userId)
+    return NextResponse.json({ error: "Organizer only" }, { status: 403 });
+
+  const body = await request.json().catch(() => null);
+  const update: Record<string, unknown> = {};
+  if (typeof body?.name === "string") update.name = body.name;
+  if (typeof body?.start_date === "string") update.start_date = body.start_date;
+  if (typeof body?.end_date === "string") update.end_date = body.end_date;
+
+  const nextStart = (update.start_date as string | undefined) ?? access.start_date;
+  const nextEnd = (update.end_date as string | undefined) ?? access.end_date;
+  if (nextStart > nextEnd) {
+    return NextResponse.json(
+      { error: "start_date must be on or before end_date" },
+      { status: 400 }
+    );
+  }
+  update.status = classifyTripStatus(nextStart, nextEnd);
+
+  const { data, error } = await supabase
+    .from("trips")
+    .update(update)
+    .eq("id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // If dates moved, reconcile trip_days: add new dates, drop dropped ones.
+  if (update.start_date || update.end_date) {
+    const want = new Set(enumerateDates(nextStart, nextEnd));
+    const { data: existing } = await supabase
+      .from("trip_days")
+      .select("id, date")
+      .eq("trip_id", id);
+    const have = new Set((existing ?? []).map((d) => d.date));
+    const toInsert = [...want]
+      .filter((d) => !have.has(d))
+      .map((d) => ({ trip_id: id, date: d }));
+    const toDeleteIds = (existing ?? [])
+      .filter((d) => !want.has(d.date))
+      .map((d) => d.id);
+    if (toInsert.length > 0) await supabase.from("trip_days").insert(toInsert);
+    if (toDeleteIds.length > 0)
+      await supabase.from("trip_days").delete().in("id", toDeleteIds);
+  }
+
+  return NextResponse.json({ trip: data });
+}
+
+export async function DELETE(_request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (access.owner_user_id !== userId)
+    return NextResponse.json({ error: "Organizer only" }, { status: 403 });
+
+  const { error } = await supabase.from("trips").delete().eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/trips/[id]/stops/[stopId]/route.ts
+++ b/src/app/api/v1/trips/[id]/stops/[stopId]/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip } from "@/lib/trips";
+
+type RouteContext = { params: Promise<{ id: string; stopId: string }> };
+
+export async function PATCH(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id, stopId } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const update: Record<string, unknown> = {};
+  if (typeof body?.name === "string") update.name = body.name;
+  if (body?.latitude !== undefined) update.latitude = body.latitude;
+  if (body?.longitude !== undefined) update.longitude = body.longitude;
+  if (Array.isArray(body?.activities)) update.activities = body.activities;
+
+  const { data, error } = await supabase
+    .from("trip_stops")
+    .update(update)
+    .eq("id", stopId)
+    .eq("trip_id", id)
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Allow assigning days to this stop in the same call.
+  if (Array.isArray(body?.day_dates)) {
+    const dates = body.day_dates as string[];
+    if (dates.length > 0) {
+      await supabase
+        .from("trip_days")
+        .update({ stop_id: stopId })
+        .eq("trip_id", id)
+        .in("date", dates);
+    }
+  }
+
+  return NextResponse.json({ stop: data });
+}
+
+export async function DELETE(_request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id, stopId } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { error } = await supabase
+    .from("trip_stops")
+    .delete()
+    .eq("id", stopId)
+    .eq("trip_id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/trips/[id]/stops/route.ts
+++ b/src/app/api/v1/trips/[id]/stops/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import { assertCanAccessTrip } from "@/lib/trips";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const { name, latitude, longitude, activities } = (body ?? {}) as {
+    name?: string;
+    latitude?: number | null;
+    longitude?: number | null;
+    activities?: string[];
+  };
+  if (!name) return NextResponse.json({ error: "name required" }, { status: 400 });
+
+  const { data: existing } = await supabase
+    .from("trip_stops")
+    .select("position")
+    .eq("trip_id", id)
+    .order("position", { ascending: false })
+    .limit(1);
+  const nextPosition = ((existing?.[0]?.position as number | undefined) ?? -1) + 1;
+
+  const { data, error } = await supabase
+    .from("trip_stops")
+    .insert({
+      trip_id: id,
+      position: nextPosition,
+      name,
+      latitude: latitude ?? null,
+      longitude: longitude ?? null,
+      activities: activities ?? [],
+    })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ stop: data }, { status: 201 });
+}
+
+export async function PUT(request: NextRequest, ctx: RouteContext) {
+  // Reorder: body is { order: [stopId, stopId, ...] }
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase || !userId)
+    return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const { id } = await ctx.params;
+  const access = await assertCanAccessTrip(supabase, id, userId);
+  if (!access) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await request.json().catch(() => null);
+  const order = (body?.order ?? []) as string[];
+  if (!Array.isArray(order))
+    return NextResponse.json({ error: "order array required" }, { status: 400 });
+
+  // Two-phase update to avoid the unique (trip_id, position) collision.
+  for (let i = 0; i < order.length; i++) {
+    await supabase
+      .from("trip_stops")
+      .update({ position: -(i + 1) })
+      .eq("id", order[i])
+      .eq("trip_id", id);
+  }
+  for (let i = 0; i < order.length; i++) {
+    await supabase
+      .from("trip_stops")
+      .update({ position: i })
+      .eq("id", order[i])
+      .eq("trip_id", id);
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/trips/invite/[token]/route.ts
+++ b/src/app/api/v1/trips/invite/[token]/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+
+type RouteContext = { params: Promise<{ token: string }> };
+
+// GET — public preview of an invite. Returns trip name/dates so the landing
+// page can render before the user signs in.
+export async function GET(_request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  if (!supabase)
+    return NextResponse.json({ error: "Database not configured" }, { status: 503 });
+
+  const { token } = await ctx.params;
+  const { data: member } = await supabase
+    .from("trip_members")
+    .select("id, trip_id, display_name, status, role")
+    .eq("invite_token", token)
+    .maybeSingle();
+  if (!member) return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+
+  const { data: trip } = await supabase
+    .from("trips")
+    .select("id, name, start_date, end_date")
+    .eq("id", member.trip_id)
+    .maybeSingle();
+  if (!trip) return NextResponse.json({ error: "Trip not found" }, { status: 404 });
+
+  const { data: organizer } = await supabase
+    .from("trip_members")
+    .select("display_name")
+    .eq("trip_id", trip.id)
+    .eq("role", "organizer")
+    .maybeSingle();
+
+  return NextResponse.json({
+    invite: {
+      display_name: member.display_name,
+      status: member.status,
+    },
+    trip: {
+      id: trip.id,
+      name: trip.name,
+      start_date: trip.start_date,
+      end_date: trip.end_date,
+    },
+    organizer_name: organizer?.display_name ?? null,
+  });
+}
+
+// POST — accept the invite. Requires a signed-in Clerk user.
+export async function POST(_request: NextRequest, ctx: RouteContext) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase)
+    return NextResponse.json({ error: "Database not configured" }, { status: 503 });
+  if (!userId)
+    return NextResponse.json({ error: "Sign in required" }, { status: 401 });
+
+  const { token } = await ctx.params;
+
+  const { data: member } = await supabase
+    .from("trip_members")
+    .select("id, trip_id, status, user_id")
+    .eq("invite_token", token)
+    .maybeSingle();
+  if (!member)
+    return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+  if (member.status === "joined" && member.user_id === userId) {
+    return NextResponse.json({ trip_id: member.trip_id, already_joined: true });
+  }
+
+  // If this Clerk user is already on the trip via another row, don't dupe.
+  const { data: existing } = await supabase
+    .from("trip_members")
+    .select("id")
+    .eq("trip_id", member.trip_id)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (existing) {
+    // Best-effort: clear the dangling invite row so the token can't be reused.
+    await supabase.from("trip_members").delete().eq("id", member.id);
+    return NextResponse.json({ trip_id: member.trip_id, already_joined: true });
+  }
+
+  const { error } = await supabase
+    .from("trip_members")
+    .update({
+      user_id: userId,
+      status: "joined",
+      invite_token: null,
+    })
+    .eq("id", member.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ trip_id: member.trip_id, already_joined: false });
+}

--- a/src/app/api/v1/trips/invite/[token]/route.ts
+++ b/src/app/api/v1/trips/invite/[token]/route.ts
@@ -83,15 +83,23 @@ export async function POST(_request: NextRequest, ctx: RouteContext) {
     return NextResponse.json({ trip_id: member.trip_id, already_joined: true });
   }
 
-  const { error } = await supabase
+  // Atomic claim: only update if the invite_token is still attached. If another
+  // request raced ahead and cleared the token, no row is returned and we report
+  // the conflict instead of silently overwriting their claim.
+  const { data: accepted, error } = await supabase
     .from("trip_members")
     .update({
       user_id: userId,
       status: "joined",
       invite_token: null,
     })
-    .eq("id", member.id);
+    .eq("id", member.id)
+    .eq("invite_token", token)
+    .select("trip_id")
+    .maybeSingle();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!accepted)
+    return NextResponse.json({ error: "Invite already used" }, { status: 409 });
 
-  return NextResponse.json({ trip_id: member.trip_id, already_joined: false });
+  return NextResponse.json({ trip_id: accepted.trip_id, already_joined: false });
 }

--- a/src/app/api/v1/trips/route.ts
+++ b/src/app/api/v1/trips/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+import { getAuthUserId } from "@/lib/auth";
+import {
+  classifyTripStatus,
+  enumerateDates,
+  listTripsForUser,
+} from "@/lib/trips";
+
+export async function GET() {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase) return NextResponse.json({ trips: [] });
+  if (!userId) return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const trips = await listTripsForUser(supabase, userId);
+  return NextResponse.json({ trips });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = getSupabase();
+  const userId = await getAuthUserId();
+  if (!supabase)
+    return NextResponse.json({ error: "Database not configured" }, { status: 503 });
+  if (!userId) return NextResponse.json({ error: "Auth required" }, { status: 401 });
+
+  const body = await request.json().catch(() => null);
+  const { name, start_date, end_date } = (body ?? {}) as {
+    name?: string;
+    start_date?: string;
+    end_date?: string;
+  };
+
+  if (!name || !start_date || !end_date) {
+    return NextResponse.json(
+      { error: "name, start_date, end_date required" },
+      { status: 400 }
+    );
+  }
+  if (start_date > end_date) {
+    return NextResponse.json(
+      { error: "start_date must be on or before end_date" },
+      { status: 400 }
+    );
+  }
+
+  const status = classifyTripStatus(start_date, end_date);
+
+  const { data: trip, error } = await supabase
+    .from("trips")
+    .insert({
+      owner_user_id: userId,
+      name,
+      start_date,
+      end_date,
+      status,
+    })
+    .select("*")
+    .single();
+
+  if (error || !trip) {
+    return NextResponse.json(
+      { error: error?.message ?? "Failed to create trip" },
+      { status: 500 }
+    );
+  }
+
+  // Seed the day rows up front so day-detail joins are simple.
+  const dates = enumerateDates(start_date, end_date);
+  if (dates.length > 0) {
+    await supabase
+      .from("trip_days")
+      .insert(dates.map((d) => ({ trip_id: trip.id, date: d })));
+  }
+
+  // Organizer is the first member.
+  await supabase.from("trip_members").insert({
+    trip_id: trip.id,
+    user_id: userId,
+    display_name: "You",
+    role: "organizer",
+    status: "joined",
+  });
+
+  return NextResponse.json({ trip }, { status: 201 });
+}

--- a/src/app/trips/[id]/days/[date]/page.tsx
+++ b/src/app/trips/[id]/days/[date]/page.tsx
@@ -1,0 +1,563 @@
+"use client";
+
+import { use, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  Chip,
+  GarmentGlyph,
+  MemberAvatar,
+  SectionLabel,
+  WeatherGlyph,
+  inferWeatherKind,
+} from "@/components/trips/trip-primitives";
+import { useTrip } from "@/hooks/useTrip";
+import { TRIP_ACTIVITY_OPTIONS } from "@/lib/trip-activities";
+import { LocationAutocomplete } from "@/components/LocationAutocomplete";
+import { useLocationSearch } from "@/hooks/useLocationSearch";
+import type { TripEffort, TripKitState, TripMember, TripMemberDayKit, TripStop } from "@/types/trips";
+
+const KIT_SLOTS = ["shirt", "midlayer", "jacket", "shell", "pants", "gloves"] as const;
+const EFFORT_OPTIONS: TripEffort[] = ["easy", "steady", "hard"];
+
+export default function DayDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string; date: string }>;
+}) {
+  const { id, date } = use(params);
+  const { data, loading, error, refresh } = useTrip(id);
+  // tempF/wind in imperial units (matches /api/weather), precip is a 0–1 fraction
+  // representing the day's peak precipitation probability.
+  const [weather, setWeather] = useState<{ tempF: number; precip: number; wind: number } | null>(
+    null
+  );
+
+  const day = data?.days.find((d) => d.date === date);
+  const assignedStop = day?.stop_id ? data?.stops.find((s) => s.id === day.stop_id) : undefined;
+  // Fall back to the trip's first stop (its "base location") when this day
+  // doesn't have a stop of its own, so forecasts still work for solo trips
+  // and travel days without a planned stop.
+  const baseStop = data?.stops[0];
+  const effectiveStop = assignedStop ?? baseStop;
+  const usingBaseFallback = !assignedStop && !!baseStop;
+
+  useEffect(() => {
+    if (!effectiveStop?.latitude || !effectiveStop?.longitude) {
+      setWeather(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(
+      `/api/weather?lat=${effectiveStop.latitude}&lon=${effectiveStop.longitude}&startDate=${date}&days=1`
+    )
+      .then((r) => r.json())
+      .then((body: { hourly?: Array<{ time: string; temperature: number; windSpeed: number; precipitationProbability: number }> }) => {
+        if (cancelled) return;
+        const hourly = Array.isArray(body?.hourly) ? body.hourly : [];
+        // Average across the active daytime window (8am–6pm) for a representative
+        // "what's the day going to feel like" reading, with peak-precip and
+        // peak-wind so kit decisions don't miss a single bad hour.
+        const daytime = hourly.filter((h) => {
+          const hour = Number(h.time?.slice(11, 13));
+          return hour >= 8 && hour <= 18;
+        });
+        const sample = daytime.length > 0 ? daytime : hourly;
+        if (sample.length === 0) return;
+        const avgTemp =
+          sample.reduce((acc, h) => acc + (h.temperature ?? 0), 0) / sample.length;
+        const peakWind = sample.reduce((acc, h) => Math.max(acc, h.windSpeed ?? 0), 0);
+        const peakPrecip = sample.reduce(
+          (acc, h) => Math.max(acc, h.precipitationProbability ?? 0),
+          0
+        );
+        setWeather({
+          tempF: avgTemp,
+          wind: peakWind,
+          precip: peakPrecip / 100, // /api/weather returns 0–100, normalize for inferWeatherKind
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [effectiveStop?.latitude, effectiveStop?.longitude, date]);
+
+  const dateObj = new Date(`${date}T00:00:00`);
+  const dateLabel = dateObj.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+  const activeMembers = useMemo(
+    () => data?.members.filter((m) => m.status !== "left") ?? [],
+    [data?.members]
+  );
+
+  // Find prev/next day for arrows.
+  const dayIndex = data?.days.findIndex((d) => d.date === date) ?? -1;
+  const prevDay = dayIndex > 0 ? data?.days[dayIndex - 1] : undefined;
+  const nextDay =
+    dayIndex >= 0 && data && dayIndex < data.days.length - 1 ? data.days[dayIndex + 1] : undefined;
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-3xl flex-col gap-5">
+        <div className="flex items-center gap-3">
+          <Link
+            href={`/trips/${id}`}
+            className="inline-flex items-center gap-1.5 text-sm text-white/70 hover:text-white"
+          >
+            <ArrowLeft className="size-4" />
+            Trip
+          </Link>
+          <div className="ml-auto flex items-center gap-1">
+            {prevDay && (
+              <Link
+                href={`/trips/${id}/days/${prevDay.date}`}
+                className="rounded-md p-1 text-white/55 hover:bg-white/10 hover:text-white"
+              >
+                <ChevronLeft className="size-5" />
+              </Link>
+            )}
+            {nextDay && (
+              <Link
+                href={`/trips/${id}/days/${nextDay.date}`}
+                className="rounded-md p-1 text-white/55 hover:bg-white/10 hover:text-white"
+              >
+                <ChevronRight className="size-5" />
+              </Link>
+            )}
+          </div>
+        </div>
+
+        {loading && <Skeleton className="h-32 w-full rounded-2xl bg-white/12" />}
+        {error && (
+          <div className="rounded-xl border border-orange-400/35 bg-orange-300/10 px-4 py-3 text-sm text-orange-100">
+            {error}
+          </div>
+        )}
+
+        {data && day && (
+          <>
+            <header>
+              <SectionLabel>
+                Day {dayIndex + 1} of {data.days.length} ·{" "}
+                {day.activity ?? effectiveStop?.activities[0] ?? "no activity"}
+              </SectionLabel>
+              <h1 className="mt-1 text-[2rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+                {dateLabel}
+              </h1>
+              {effectiveStop && (
+                <p className="mt-1 text-sm text-white/65">
+                  {effectiveStop.name}
+                  {usingBaseFallback && (
+                    <span className="ml-1.5 text-[11px] uppercase tracking-wide text-white/45">
+                      · base location
+                    </span>
+                  )}
+                </p>
+              )}
+            </header>
+
+            <ActivityPicker
+              tripId={id}
+              date={date}
+              current={day.activity ?? null}
+              suggested={effectiveStop?.activities ?? []}
+              onChange={() => refresh()}
+            />
+
+            <WeatherCard
+              tripId={id}
+              stop={effectiveStop ?? null}
+              weather={weather}
+              onLocationSaved={() => refresh()}
+            />
+
+            <section className="flex flex-col gap-2.5">
+              <SectionLabel>Crew kits</SectionLabel>
+              {activeMembers.map((m) => (
+                <MemberKitRow
+                  key={m.id}
+                  tripId={id}
+                  date={date}
+                  member={m}
+                  kit={data.kits.find(
+                    (k) => k.trip_member_id === m.id && data.days.find((d) => d.id === k.trip_day_id)?.date === date
+                  )}
+                  onChange={() => refresh()}
+                />
+              ))}
+            </section>
+
+            <div className="h-24" />
+          </>
+        )}
+      </div>
+    </PageLayout>
+  );
+}
+
+function WeatherCard({
+  tripId,
+  stop,
+  weather,
+  onLocationSaved,
+}: {
+  tripId: string;
+  stop: TripStop | null;
+  weather: { tempF: number; precip: number; wind: number } | null;
+  onLocationSaved: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const search = useLocationSearch();
+
+  const hasCoords = !!stop?.latitude && !!stop?.longitude;
+
+  const save = async () => {
+    const selected = search.selectedLocation;
+    if (!selected) return;
+    setSaving(true);
+    try {
+      const name = selected.region
+        ? `${selected.name}, ${selected.region}`
+        : `${selected.name}, ${selected.country}`;
+      if (stop) {
+        await fetch(`/api/v1/trips/${tripId}/stops/${stop.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name,
+            latitude: selected.latitude,
+            longitude: selected.longitude,
+          }),
+        });
+      } else {
+        await fetch(`/api/v1/trips/${tripId}/stops`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name,
+            latitude: selected.latitude,
+            longitude: selected.longitude,
+            activities: [],
+          }),
+        });
+      }
+      search.reset();
+      setEditing(false);
+      onLocationSaved();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <div className="flex items-center gap-3">
+        <WeatherGlyph
+          kind={weather ? inferWeatherKind(weather.tempF, weather.precip) : "cloud"}
+          className="size-8"
+        />
+        <div className="flex-1">
+          {weather ? (
+            <>
+              <p className="text-base font-semibold text-white">
+                {Math.round(weather.tempF)}°F · {Math.round(weather.wind)} mph
+              </p>
+              <p className="text-xs text-white/55">
+                {weather.precip > 0.6
+                  ? "wet day · plan a shell"
+                  : weather.precip > 0.3
+                  ? "showers possible"
+                  : "dry"}
+              </p>
+            </>
+          ) : hasCoords ? (
+            <p className="text-sm text-white/60">Loading forecast…</p>
+          ) : (
+            <p className="text-sm text-white/60">
+              {stop
+                ? "This stop has no coordinates yet."
+                : "Set a base location to fetch the forecast."}
+            </p>
+          )}
+        </div>
+        {hasCoords ? (
+          <button
+            type="button"
+            onClick={() => setEditing((v) => !v)}
+            className="rounded-md border border-white/12 px-2 py-1 text-[11px] text-white/65 hover:bg-white/[0.08]"
+          >
+            {editing ? "Cancel" : "Change"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="rounded-md border border-cyan-300/45 bg-cyan-300/15 px-2.5 py-1 text-[11px] font-medium text-cyan-50 hover:bg-cyan-300/25"
+          >
+            Set location
+          </button>
+        )}
+      </div>
+      {editing && (
+        <div className="mt-3 border-t border-white/8 pt-3">
+          <LocationAutocomplete
+            id="day-stop-location"
+            placeholder="Search a city or place…"
+            location={search.location}
+            locationQuery={search.locationQuery}
+            suggestions={search.suggestions}
+            showSuggestions={search.showSuggestions}
+            selectedLocation={search.selectedLocation}
+            isSearching={search.isSearching}
+            suggestionRef={search.suggestionRef}
+            onLocationInputChange={search.handleLocationInputChange}
+            onLocationFocus={() =>
+              search.suggestions.length > 0 && search.setShowSuggestions(true)
+            }
+            onSelectLocation={search.handleSelectLocation}
+            onDismiss={search.dismiss}
+          />
+          <button
+            type="button"
+            onClick={save}
+            disabled={!search.selectedLocation || saving}
+            className="mt-3 inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-white/14 bg-cyan-300/22 px-4 text-sm font-medium text-white disabled:opacity-50"
+          >
+            {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+            Save location
+          </button>
+          <p className="mt-1.5 text-xs text-white/45">
+            {stop
+              ? "Updates this stop for every day at it."
+              : "Adds a base location to the trip."}
+          </p>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function ActivityPicker({
+  tripId,
+  date,
+  current,
+  suggested,
+  onChange,
+}: {
+  tripId: string;
+  date: string;
+  current: string | null;
+  suggested: string[];
+  onChange: () => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [value, setValue] = useState<string | null>(current);
+
+  useEffect(() => {
+    setValue(current);
+  }, [current]);
+
+  const merged = useMemo(() => {
+    const set = new Set<string>(TRIP_ACTIVITY_OPTIONS);
+    for (const a of suggested) set.add(a);
+    if (current && !set.has(current)) set.add(current);
+    return Array.from(set);
+  }, [suggested, current]);
+
+  const setActivity = async (next: string | null) => {
+    setValue(next);
+    setSaving(true);
+    try {
+      await fetch(`/api/v1/trips/${tripId}/days/${date}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ activity: next }),
+      });
+      onChange();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between">
+        <SectionLabel>Activity</SectionLabel>
+        {saving && <Loader2 className="size-3.5 animate-spin text-white/45" />}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {merged.map((a) => {
+          const on = value === a;
+          const fromStop = suggested.includes(a);
+          return (
+            <button
+              key={a}
+              type="button"
+              onClick={() => setActivity(on ? null : a)}
+              className={
+                "rounded-full border px-3 py-1 text-xs transition-colors " +
+                (on
+                  ? "border-cyan-300/55 bg-cyan-300/22 text-white"
+                  : fromStop
+                  ? "border-white/22 bg-white/[0.08] text-white/85"
+                  : "border-white/14 bg-white/[0.04] text-white/65 hover:bg-white/[0.08]")
+              }
+            >
+              {a}
+              {fromStop && !on && <span className="ml-1 text-white/40">·</span>}
+            </button>
+          );
+        })}
+      </div>
+      {value === null && (
+        <p className="mt-2 text-xs text-white/45">Tap a chip to set this day&apos;s activity.</p>
+      )}
+    </Card>
+  );
+}
+
+function MemberKitRow({
+  tripId,
+  date,
+  member,
+  kit,
+  onChange,
+}: {
+  tripId: string;
+  date: string;
+  member: TripMember;
+  kit: TripMemberDayKit | undefined;
+  onChange: () => void;
+}) {
+  const [effort, setEffort] = useState<TripEffort>(kit?.effort ?? "steady");
+  const [items, setItems] = useState<string[]>(kit?.items ?? []);
+  const [state, setState] = useState<TripKitState>(kit?.state ?? "ok");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setEffort(kit?.effort ?? "steady");
+    setItems(kit?.items ?? []);
+    setState(kit?.state ?? "ok");
+  }, [kit?.id, kit?.effort, kit?.items, kit?.state]);
+
+  const persist = async (next: {
+    effort?: TripEffort;
+    items?: string[];
+    state?: TripKitState;
+  }) => {
+    setSaving(true);
+    try {
+      const body = {
+        effort: next.effort ?? effort,
+        items: next.items ?? items,
+        state: next.state ?? state,
+        note: kit?.note ?? null,
+      };
+      await fetch(`/api/v1/trips/${tripId}/days/${date}/kits/${member.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      onChange();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleItem = (slot: string) => {
+    const next = items.includes(slot) ? items.filter((x) => x !== slot) : [...items, slot];
+    setItems(next);
+    persist({ items: next });
+  };
+
+  return (
+    <Card highlighted={state === "warn"}>
+      <div className="flex flex-wrap items-center gap-3">
+        <MemberAvatar
+          name={member.display_name}
+          size={28}
+          state={member.role === "organizer" ? "self" : "default"}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-white">{member.display_name}</p>
+          <p className="text-xs text-white/55">
+            {state === "warn"
+              ? "thin — borrow a layer?"
+              : items.length === 0
+              ? "no kit set"
+              : `${items.length} layers picked`}
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          {EFFORT_OPTIONS.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => {
+                setEffort(opt);
+                persist({ effort: opt });
+              }}
+              className={
+                "rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide " +
+                (effort === opt
+                  ? "border-cyan-300/55 bg-cyan-300/22 text-white"
+                  : "border-white/14 bg-white/[0.05] text-white/65")
+              }
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+        {saving && <Loader2 className="size-3.5 animate-spin text-white/45" />}
+      </div>
+      <div className="mt-2.5 flex flex-wrap gap-1">
+        {KIT_SLOTS.map((slot) => {
+          const on = items.includes(slot);
+          return (
+            <button
+              key={slot}
+              type="button"
+              onClick={() => toggleItem(slot)}
+              className={
+                "flex items-center gap-1 rounded-md border px-2 py-1 text-[10px] uppercase tracking-wide " +
+                (on
+                  ? "border-cyan-300/55 bg-cyan-300/15 text-white"
+                  : "border-white/12 bg-transparent text-white/55")
+              }
+            >
+              <GarmentGlyph kind={slot} className="size-3.5" />
+              {slot}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {state === "warn" ? (
+          <Chip variant="warn">needs help</Chip>
+        ) : (
+          <Chip>{state}</Chip>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            const next: TripKitState = state === "warn" ? "ok" : "warn";
+            setState(next);
+            persist({ state: next });
+          }}
+          className="rounded-full border border-white/14 px-2.5 py-0.5 text-[10px] text-white/65 hover:text-white"
+        >
+          flag {state === "warn" ? "ok" : "warn"}
+        </button>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/trips/[id]/gear/page.tsx
+++ b/src/app/trips/[id]/gear/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { use, useState } from "react";
+import Link from "next/link";
+import { AlertTriangle, ArrowLeft, Loader2, Plus, X } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, SectionLabel } from "@/components/trips/trip-primitives";
+import { useTrip } from "@/hooks/useTrip";
+
+export default function GroupGearPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { data, loading, error, refresh } = useTrip(id);
+  const [description, setDescription] = useState("");
+  const [assignee, setAssignee] = useState<string>("");
+  const [adding, setAdding] = useState(false);
+
+  const members = data?.members ?? [];
+
+  const addGear = async () => {
+    if (!description.trim()) return;
+    setAdding(true);
+    try {
+      await fetch(`/api/v1/trips/${id}/gear`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          description: description.trim(),
+          assignee_member_id: assignee || null,
+        }),
+      });
+      setDescription("");
+      setAssignee("");
+      await refresh();
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const updateAssignee = async (gearId: string, memberId: string | null) => {
+    await fetch(`/api/v1/trips/${id}/gear/${gearId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ assignee_member_id: memberId }),
+    });
+    await refresh();
+  };
+
+  const remove = async (gearId: string) => {
+    await fetch(`/api/v1/trips/${id}/gear/${gearId}`, { method: "DELETE" });
+    await refresh();
+  };
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-2xl flex-col gap-5">
+        <Link
+          href={`/trips/${id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-white/70 hover:text-white"
+        >
+          <ArrowLeft className="size-4" />
+          Trip
+        </Link>
+        <header>
+          <SectionLabel>Shared gear</SectionLabel>
+          <h1 className="mt-1 text-[2rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+            Who&apos;s bringing what?
+          </h1>
+        </header>
+
+        {loading && <Skeleton className="h-32 w-full rounded-2xl bg-white/12" />}
+        {error && (
+          <div className="rounded-xl border border-orange-400/35 bg-orange-300/10 px-4 py-3 text-sm text-orange-100">
+            {error}
+          </div>
+        )}
+
+        {data && (
+          <>
+            <div className="flex flex-col gap-2">
+              {data.gear.length === 0 && (
+                <Card>
+                  <p className="text-sm text-white/65">No group gear yet.</p>
+                </Card>
+              )}
+              {data.gear.map((g) => {
+                const assigned = g.assignee_member_id
+                  ? members.find((m) => m.id === g.assignee_member_id)?.display_name
+                  : null;
+                return (
+                  <Card key={g.id} highlighted={!assigned}>
+                    <div className="flex items-center gap-3">
+                      <p className="flex-1 truncate text-sm text-white/90">{g.description}</p>
+                      <select
+                        value={g.assignee_member_id ?? ""}
+                        onChange={(e) =>
+                          updateAssignee(g.id, e.target.value === "" ? null : e.target.value)
+                        }
+                        className="rounded-md border border-white/14 bg-white/[0.06] px-2 py-1 text-xs text-white"
+                      >
+                        <option value="">unassigned</option>
+                        {members
+                          .filter((m) => m.status !== "left")
+                          .map((m) => (
+                            <option key={m.id} value={m.id}>
+                              {m.display_name}
+                            </option>
+                          ))}
+                      </select>
+                      {!assigned && (
+                        <AlertTriangle className="size-4 text-orange-300" aria-label="Unassigned" />
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => remove(g.id)}
+                        aria-label="Remove gear"
+                        className="rounded-md p-1 text-white/55 hover:bg-white/10 hover:text-white"
+                      >
+                        <X className="size-4" />
+                      </button>
+                    </div>
+                  </Card>
+                );
+              })}
+            </div>
+
+            <Card>
+              <SectionLabel className="mb-2">Add gear</SectionLabel>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <input
+                  type="text"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Tent, stove, first aid…"
+                  className="h-10 flex-1 rounded-lg border border-white/12 bg-white/[0.06] px-3 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+                />
+                <select
+                  value={assignee}
+                  onChange={(e) => setAssignee(e.target.value)}
+                  className="h-10 rounded-lg border border-white/12 bg-white/[0.06] px-2 text-sm text-white"
+                >
+                  <option value="">unassigned</option>
+                  {members
+                    .filter((m) => m.status !== "left")
+                    .map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.display_name}
+                      </option>
+                    ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={addGear}
+                  disabled={!description.trim() || adding}
+                  className="inline-flex h-10 items-center gap-1.5 rounded-lg border border-white/14 bg-white/[0.08] px-3 text-sm font-medium text-white disabled:opacity-50"
+                >
+                  {adding ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+                  Add
+                </button>
+              </div>
+            </Card>
+
+            <div className="h-24" />
+          </>
+        )}
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/trips/[id]/manage/page.tsx
+++ b/src/app/trips/[id]/manage/page.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Loader2, Trash2, UserPlus, X } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  InviteLinkButton,
+  MemberAvatar,
+  SectionLabel,
+} from "@/components/trips/trip-primitives";
+import { useTrip } from "@/hooks/useTrip";
+import type { TripMember } from "@/types/trips";
+
+export default function ManageCrewPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { data, loading, error, refresh } = useTrip(id);
+  const [adding, setAdding] = useState(false);
+  const [name, setName] = useState("");
+  const [kind, setKind] = useState<"invite" | "guest">("invite");
+  const [confirming, setConfirming] = useState<TripMember | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  const add = async () => {
+    if (!name.trim()) return;
+    setAdding(true);
+    try {
+      await fetch(`/api/v1/trips/${id}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ display_name: name.trim(), kind }),
+      });
+      setName("");
+      await refresh();
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!confirming) return;
+    setRemoving(true);
+    try {
+      await fetch(`/api/v1/trips/${id}/members/${confirming.id}`, { method: "DELETE" });
+      setConfirming(null);
+      await refresh();
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-2xl flex-col gap-5">
+        <Link
+          href={`/trips/${id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-white/70 hover:text-white"
+        >
+          <ArrowLeft className="size-4" />
+          Trip
+        </Link>
+        <header>
+          <SectionLabel>Trip settings</SectionLabel>
+          <h1 className="mt-1 text-[2rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+            Manage crew
+          </h1>
+        </header>
+
+        {loading && <Skeleton className="h-32 w-full rounded-2xl bg-white/12" />}
+        {error && (
+          <div className="rounded-xl border border-orange-400/35 bg-orange-300/10 px-4 py-3 text-sm text-orange-100">
+            {error}
+          </div>
+        )}
+
+        {data && (
+          <>
+            <div className="flex flex-col gap-2">
+              {data.members.map((m) => (
+                <Card key={m.id}>
+                  <div className="flex items-center gap-3">
+                    <MemberAvatar
+                      name={m.display_name}
+                      state={
+                        m.role === "organizer"
+                          ? "self"
+                          : m.status === "guest"
+                          ? "guest"
+                          : m.status === "invited"
+                          ? "invited"
+                          : "default"
+                      }
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold text-white">
+                        {m.display_name}
+                      </p>
+                      <p className="text-xs text-white/55">
+                        {m.role} · {m.status === "left" ? "left" : m.status}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      {m.status === "invited" && m.invite_token && (
+                        <InviteLinkButton
+                          token={m.invite_token}
+                          recipientName={m.display_name}
+                          tripName={data.trip.name}
+                        />
+                      )}
+                      {m.role !== "organizer" && (
+                        <button
+                          type="button"
+                          onClick={() => setConfirming(m)}
+                          className="inline-flex items-center gap-1 rounded-md border border-white/12 px-2.5 py-1.5 text-xs text-white/70 hover:border-orange-300/40 hover:bg-orange-300/10 hover:text-orange-50"
+                          aria-label={`Remove ${m.display_name}`}
+                        >
+                          <Trash2 className="size-3.5" />
+                          Remove
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+
+            <Card>
+              <SectionLabel className="mb-2">Add member</SectionLabel>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Display name"
+                  className="h-10 flex-1 rounded-lg border border-white/12 bg-white/[0.06] px-3 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+                />
+                <button
+                  type="button"
+                  onClick={add}
+                  disabled={!name.trim() || adding}
+                  className="inline-flex h-10 items-center gap-1.5 rounded-lg border border-white/14 bg-white/[0.08] px-3 text-sm font-medium text-white disabled:opacity-50"
+                >
+                  {adding ? <Loader2 className="size-4 animate-spin" /> : <UserPlus className="size-4" />}
+                  Add
+                </button>
+              </div>
+              <div className="mt-3 flex gap-2">
+                {(["invite", "guest"] as const).map((k) => (
+                  <button
+                    key={k}
+                    type="button"
+                    onClick={() => setKind(k)}
+                    className={
+                      "flex-1 rounded-lg border px-3 py-2 text-xs font-medium transition-colors " +
+                      (kind === k
+                        ? "border-cyan-300/55 bg-cyan-300/15 text-white"
+                        : "border-white/14 bg-white/[0.05] text-white/72")
+                    }
+                  >
+                    {k === "invite" ? "Send invite" : "Guest (no signup)"}
+                  </button>
+                ))}
+              </div>
+            </Card>
+
+            <p className="text-center text-xs text-white/45">
+              Removing a member soft-deletes them. They keep their kit drafts on their device.
+            </p>
+            <div className="h-24" />
+          </>
+        )}
+
+        {confirming && (
+          <RemoveConfirmModal
+            member={confirming}
+            removing={removing}
+            onCancel={() => setConfirming(null)}
+            onConfirm={remove}
+          />
+        )}
+      </div>
+    </PageLayout>
+  );
+}
+
+function RemoveConfirmModal({
+  member,
+  removing,
+  onCancel,
+  onConfirm,
+}: {
+  member: TripMember;
+  removing: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const sideEffects = [
+    "unassign their group gear",
+    "drop them from roll call",
+    "keep their kit drafts on their device",
+  ];
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !removing) onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel, removing]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Remove ${member.display_name} from trip`}
+      onClick={() => !removing && onCancel()}
+      className="fixed inset-0 z-50 flex items-end justify-center overflow-y-auto bg-black/55 backdrop-blur-sm sm:items-center"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="relative w-full max-w-md rounded-t-3xl border border-white/14 bg-slate-950/95 p-5 shadow-[0_-12px_40px_rgba(0,0,0,0.5)] pb-[calc(env(safe-area-inset-bottom)+5.5rem)] sm:rounded-3xl sm:pb-5"
+      >
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Close"
+          className="absolute right-3 top-3 rounded-md p-1.5 text-white/55 hover:bg-white/10 hover:text-white"
+        >
+          <X className="size-5" />
+        </button>
+        <SectionLabel>Remove from trip</SectionLabel>
+        <div className="mt-3 flex items-center gap-3 rounded-2xl border border-orange-400/35 bg-orange-300/10 px-3 py-3">
+          <MemberAvatar name={member.display_name} size={40} />
+          <div>
+            <p className="text-base font-semibold text-white">{member.display_name}</p>
+            <p className="text-xs text-white/65">{member.role} · {member.status}</p>
+          </div>
+        </div>
+        <p className="mt-4 text-sm text-white/85">Removing {member.display_name} will:</p>
+        <ul className="mt-2 space-y-1.5">
+          {sideEffects.map((t) => (
+            <li key={t} className="flex gap-2 text-xs text-white/75">
+              <span className="text-cyan-300">·</span>
+              {t}
+            </li>
+          ))}
+        </ul>
+        <div className="mt-5 flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={removing}
+            className="inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-orange-300/45 bg-orange-300/22 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            {removing && <Loader2 className="size-4 animate-spin" />}
+            Remove {member.display_name}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={removing}
+            className="inline-flex h-11 items-center justify-center rounded-xl border border-white/14 text-sm text-white/80 hover:bg-white/10 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/trips/[id]/pack/page.tsx
+++ b/src/app/trips/[id]/pack/page.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { use, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { AlertTriangle, ArrowLeft, Loader2, RefreshCw } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, Chip, SectionLabel } from "@/components/trips/trip-primitives";
+import type { PackingListData } from "@/lib/packingList";
+
+interface TripPackResponse {
+  trip: { id: string; name: string; start_date: string; end_date: string };
+  coveredDays: number;
+  totalDays: number;
+  skipped: { date: string; reason: string }[];
+  packingList: PackingListData;
+  groupGear: string[];
+}
+
+const BODY_PART_LABEL: Record<string, string> = {
+  torso: "Torso",
+  legs: "Legs",
+  hands: "Hands",
+  headNeck: "Head & neck",
+};
+
+const LAYER_LABEL: Record<string, string> = {
+  base: "Base",
+  mid: "Mid",
+  outer: "Outer",
+};
+
+const SKIP_REASON_LABEL: Record<string, string> = {
+  no_stop: "trip has no base location yet",
+  no_coords: "base location missing coordinates",
+  no_activity: "no activity set",
+  activity_unsupported: "activity not yet supported by the engine",
+};
+
+export default function PackListPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [data, setData] = useState<TripPackResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = async () => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/v1/trips/${id}/pack`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Failed (${res.status})`);
+      }
+      const body = (await res.json()) as TripPackResponse;
+      setData(body);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load pack list");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const sections = useMemo(() => {
+    if (!data) return [];
+    const list = data.packingList;
+    const result: { name: string; items: { label: string; sub?: string; auto?: boolean }[] }[] = [];
+    for (const bodyPart of ["torso", "legs", "hands", "headNeck"]) {
+      const layers = list.byBodyPart[bodyPart as keyof typeof list.byBodyPart];
+      if (!layers) continue;
+      const items: { label: string; sub?: string; auto?: boolean }[] = [];
+      for (const layer of ["base", "mid", "outer"] as const) {
+        for (const entry of layers[layer]) {
+          items.push({
+            label: entry.specificItem,
+            sub: `${LAYER_LABEL[layer]} · ${entry.standardOption}`,
+            auto: entry.source === "auto",
+          });
+        }
+      }
+      if (items.length > 0) result.push({ name: BODY_PART_LABEL[bodyPart] ?? bodyPart, items });
+    }
+    return result;
+  }, [data]);
+
+  const gaps = data?.packingList.gaps ?? [];
+  const extras = data?.packingList.extras ?? [];
+  const groupGear = data?.groupGear ?? [];
+  const skipped = data?.skipped ?? [];
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-2xl flex-col gap-5">
+        <Link
+          href={`/trips/${id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-white/70 hover:text-white"
+        >
+          <ArrowLeft className="size-4" />
+          Trip
+        </Link>
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <SectionLabel>Your bag</SectionLabel>
+            <h1 className="mt-1 text-[2rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+              What to pack
+            </h1>
+            {data && (
+              <p className="mt-1 text-sm text-white/62">
+                Auto-generated from {data.coveredDays} of {data.totalDays}{" "}
+                {data.totalDays === 1 ? "day" : "days"} · activity + weather.
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setRefreshing(true);
+              load();
+            }}
+            disabled={refreshing}
+            className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-lg border border-white/14 bg-white/[0.06] px-3 text-xs font-medium text-white/85 hover:bg-white/[0.10] disabled:opacity-50"
+            aria-label="Regenerate pack list"
+          >
+            {refreshing ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3.5" />
+            )}
+            Regenerate
+          </button>
+        </header>
+
+        {loading && <Skeleton className="h-48 w-full rounded-2xl bg-white/12" />}
+        {error && (
+          <div className="rounded-xl border border-orange-400/35 bg-orange-300/10 px-4 py-3 text-sm text-orange-100">
+            {error}
+          </div>
+        )}
+
+        {data && sections.length === 0 && (
+          <Card>
+            <p className="text-sm text-white/65">
+              Nothing to pack yet — assign activities and a base location to your trip days and the
+              list will populate.
+            </p>
+          </Card>
+        )}
+
+        {sections.map((s) => (
+          <Card key={s.name}>
+            <h3 className="text-base font-semibold text-white">{s.name}</h3>
+            <ul className="mt-2 space-y-1.5">
+              {s.items.map((it, i) => (
+                <li
+                  key={`${s.name}-${i}`}
+                  className="flex items-start gap-2 text-sm text-white/85"
+                >
+                  <span className="mt-1 inline-block size-3 shrink-0 rounded-sm border border-white/22" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate">
+                      {it.label}
+                      {it.auto && (
+                        <span className="ml-2 text-[10px] uppercase tracking-wide text-cyan-300/85">
+                          from your closet
+                        </span>
+                      )}
+                    </p>
+                    {it.sub && <p className="text-xs text-white/45">{it.sub}</p>}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        ))}
+
+        {gaps.length > 0 && (
+          <Card>
+            <SectionLabel className="mb-1">Gaps you don&apos;t own yet</SectionLabel>
+            <p className="text-xs text-white/55">
+              Standard slots the recommendation engine called for that nothing in your wardrobe
+              maps to. Add an item in the Wardrobe tab to fill these in.
+            </p>
+            <ul className="mt-2 space-y-1.5">
+              {gaps.map((gap) => (
+                <li key={gap.mappingKey} className="flex items-center gap-2 text-sm text-white/85">
+                  <AlertTriangle className="size-3.5 text-orange-300" />
+                  <span className="flex-1">
+                    {gap.standardOption}{" "}
+                    <span className="text-xs text-white/50">
+                      · {BODY_PART_LABEL[gap.bodyPart] ?? gap.bodyPart} / {LAYER_LABEL[gap.layerType] ?? gap.layerType}
+                    </span>
+                  </span>
+                  <Chip variant={gap.priorityLabel === "high" ? "warn" : "outline"}>
+                    {gap.priorityLabel}
+                  </Chip>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+
+        {extras.length > 0 && (
+          <Card>
+            <h3 className="text-base font-semibold text-white">Carry items</h3>
+            <ul className="mt-2 space-y-1.5">
+              {extras.map((x) => (
+                <li key={x} className="flex items-center gap-2 text-sm text-white/85">
+                  <span className="inline-block size-3 rounded-sm border border-white/22" />
+                  {x}
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+
+        {groupGear.length > 0 && (
+          <Card>
+            <h3 className="text-base font-semibold text-white">Group gear (yours)</h3>
+            <ul className="mt-2 space-y-1.5">
+              {groupGear.map((g) => (
+                <li key={g} className="flex items-center gap-2 text-sm text-white/85">
+                  <span className="inline-block size-3 rounded-sm border border-white/22" />
+                  {g}
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+
+        {skipped.length > 0 && (
+          <Card>
+            <SectionLabel className="mb-1">Days not covered</SectionLabel>
+            <ul className="mt-2 space-y-1 text-xs text-white/55">
+              {skipped.map((s) => (
+                <li key={s.date}>
+                  {new Date(`${s.date}T00:00:00`).toLocaleDateString(undefined, {
+                    weekday: "short",
+                    month: "short",
+                    day: "numeric",
+                  })}{" "}
+                  · {SKIP_REASON_LABEL[s.reason] ?? s.reason}
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+
+        <div className="h-24" />
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/trips/[id]/page.tsx
+++ b/src/app/trips/[id]/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { ArrowLeft, ChevronRight, Package, Settings, ShieldCheck, Users } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  MemberAvatar,
+  SectionLabel,
+  Spine,
+  WeatherGlyph,
+  daysBetween,
+  formatDateRange,
+} from "@/components/trips/trip-primitives";
+import { useTrip } from "@/hooks/useTrip";
+import type { TripDay, TripStop } from "@/types/trips";
+
+const STOP_COLOR_CYCLE = ["cyan", "emerald", "amber"] as const;
+
+export default function TripOverviewPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { data, loading, error } = useTrip(id);
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-3xl flex-col gap-5">
+        <div className="flex items-center justify-between">
+          <Link
+            href="/trips"
+            className="inline-flex items-center gap-1.5 text-sm text-white/70 hover:text-white"
+          >
+            <ArrowLeft className="size-4" />
+            All trips
+          </Link>
+          {data && (
+            <Link
+              href={`/trips/${id}/manage`}
+              className="inline-flex items-center gap-1 rounded-full border border-white/14 bg-white/[0.06] px-3 py-1 text-xs text-white/80 hover:bg-white/10"
+            >
+              <Settings className="size-3.5" />
+              Edit
+            </Link>
+          )}
+        </div>
+
+        {loading && (
+          <>
+            <Skeleton className="h-24 w-full rounded-2xl bg-white/12" />
+            <Skeleton className="h-16 w-full rounded-2xl bg-white/12" />
+            <Skeleton className="h-48 w-full rounded-2xl bg-white/12" />
+          </>
+        )}
+        {error && (
+          <div className="rounded-xl border border-orange-400/35 bg-orange-300/10 px-4 py-3 text-sm text-orange-100">
+            {error}
+          </div>
+        )}
+
+        {data && (
+          <>
+            <header>
+              <SectionLabel>
+                {data.stops[0]?.name ?? "no stop"} · {daysBetween(data.trip.start_date, data.trip.end_date)} days
+              </SectionLabel>
+              <h1 className="mt-1 text-[2.25rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+                {data.trip.name}
+              </h1>
+              <p className="mt-1 text-sm text-white/62">
+                {formatDateRange(data.trip.start_date, data.trip.end_date)}
+              </p>
+            </header>
+
+            <Card>
+              <div className="flex flex-wrap items-center gap-2">
+                {data.members
+                  .filter((m) => m.status !== "left")
+                  .map((m) => (
+                    <MemberAvatar
+                      key={m.id}
+                      name={m.display_name}
+                      state={m.role === "organizer" ? "self" : m.status === "guest" ? "guest" : m.status === "invited" ? "invited" : "default"}
+                      size={32}
+                    />
+                  ))}
+                <Link
+                  href={`/trips/${id}/manage`}
+                  className="inline-flex items-center gap-1 rounded-full border border-white/14 bg-white/[0.06] px-2.5 py-1 text-xs text-white/80 hover:bg-white/10"
+                >
+                  + add
+                </Link>
+                <div className="ml-auto flex items-center gap-2">
+                  <Link
+                    href={`/trips/${id}/rollcall`}
+                    className="inline-flex items-center gap-1 rounded-full border border-cyan-300/50 bg-cyan-300/22 px-2.5 py-1 text-xs text-white"
+                  >
+                    <ShieldCheck className="size-3.5" />
+                    Roll call
+                  </Link>
+                </div>
+              </div>
+            </Card>
+
+            <Card>
+              <SectionLabel>
+                {data.stops.length} {data.stops.length === 1 ? "stop" : "stops"}
+              </SectionLabel>
+              {data.stops.length === 0 ? (
+                <p className="mt-2 text-sm text-white/55">No stops yet.</p>
+              ) : (
+                <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                  {data.stops.map((s, i) => (
+                    <span key={s.id} className="flex items-center gap-1.5">
+                      <span
+                        className={
+                          "rounded-full border px-2.5 py-0.5 text-[11px] font-semibold " +
+                          stopChipClass(i)
+                        }
+                      >
+                        {s.name}
+                      </span>
+                      {i < data.stops.length - 1 && (
+                        <span className="text-white/40">→</span>
+                      )}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </Card>
+
+            <DayList trip={data.trip} days={data.days} stops={data.stops} />
+
+            <Card>
+              <SectionLabel>Crew tools</SectionLabel>
+              <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
+                <ToolLink href={`/trips/${id}/manage`} icon={Users} label="Manage crew" />
+                <ToolLink href={`/trips/${id}/gear`} icon={Package} label="Group gear" />
+                <ToolLink href={`/trips/${id}/pack`} icon={Package} label="My pack list" />
+              </div>
+            </Card>
+
+            <div className="h-24" />
+          </>
+        )}
+      </div>
+    </PageLayout>
+  );
+}
+
+function stopChipClass(i: number) {
+  return [
+    "border-cyan-300/55 bg-cyan-300/15 text-cyan-50",
+    "border-emerald-300/55 bg-emerald-300/15 text-emerald-50",
+    "border-amber-300/55 bg-amber-300/15 text-amber-50",
+  ][i % 3];
+}
+
+function stopSpineColor(i: number): "cyan" | "emerald" | "amber" {
+  return STOP_COLOR_CYCLE[i % STOP_COLOR_CYCLE.length];
+}
+
+function DayList({
+  trip,
+  days,
+  stops,
+}: {
+  trip: { id: string };
+  days: TripDay[];
+  stops: TripStop[];
+}) {
+  const stopById = new Map(stops.map((s, i) => [s.id, { stop: s, index: i }]));
+  const baseStop = stops[0];
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SectionLabel className="mb-1">Daily plan</SectionLabel>
+      {days.map((d, i) => {
+        const prev = days[i - 1];
+        const effectiveStopId = d.stop_id ?? baseStop?.id ?? null;
+        const prevEffectiveStopId = prev ? prev.stop_id ?? baseStop?.id ?? null : null;
+        const stopChange = !prev || prevEffectiveStopId !== effectiveStopId;
+        const stopMeta = effectiveStopId ? stopById.get(effectiveStopId) : undefined;
+        const colorIndex = stopMeta?.index ?? -1;
+        const isBaseFallback = !d.stop_id && !!baseStop;
+        return (
+          <div key={d.id}>
+            {stopChange && stopMeta && (
+              <div className="mb-1.5 mt-2 flex items-center gap-2">
+                <span
+                  className={
+                    "inline-block size-1.5 rounded-full " +
+                    (colorIndex === 0
+                      ? "bg-cyan-300"
+                      : colorIndex === 1
+                      ? "bg-emerald-300"
+                      : "bg-amber-300")
+                  }
+                />
+                <SectionLabel className="!text-white/60">
+                  {stopMeta.stop.name}
+                  {isBaseFallback && (
+                    <span className="ml-1.5 text-[10px] tracking-wide text-white/40">
+                      · base
+                    </span>
+                  )}
+                </SectionLabel>
+                <span className="h-px flex-1 bg-white/10" />
+              </div>
+            )}
+            <Link href={`/trips/${trip.id}/days/${d.date}`}>
+              <Card>
+                <div className="flex items-center gap-3">
+                  {colorIndex >= 0 && <Spine color={stopSpineColor(colorIndex)} />}
+                  <div className="w-14 shrink-0">
+                    <p className="text-xs text-white/55">
+                      {new Date(`${d.date}T00:00:00`).toLocaleDateString(undefined, {
+                        weekday: "short",
+                      })}
+                    </p>
+                    <p className="text-base font-semibold text-white">
+                      {new Date(`${d.date}T00:00:00`).getDate()}
+                    </p>
+                  </div>
+                  <WeatherGlyph kind="cloud" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm text-white/85">
+                      {d.activity ?? "no activity set"}
+                    </p>
+                    <p className="text-xs text-white/55">
+                      {stopMeta
+                        ? `${stopMeta.stop.name}${isBaseFallback ? " · base" : ""}`
+                        : "Add a base location to enable forecasts"}
+                    </p>
+                  </div>
+                  <ChevronRight className="size-4 text-white/40" />
+                </div>
+              </Card>
+            </Link>
+          </div>
+        );
+      })}
+      {days.length === 0 && (
+        <p className="text-sm text-white/55">No days configured.</p>
+      )}
+    </div>
+  );
+}
+
+function ToolLink({
+  href,
+  icon: Icon,
+  label,
+}: {
+  href: string;
+  icon: typeof Users;
+  label: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-2 rounded-xl border border-white/12 bg-white/[0.05] px-3 py-2.5 text-sm text-white/85 hover:bg-white/[0.10]"
+    >
+      <Icon className="size-4 text-white/65" />
+      {label}
+      <ChevronRight className="ml-auto size-4 text-white/40" />
+    </Link>
+  );
+}

--- a/src/app/trips/[id]/rollcall/page.tsx
+++ b/src/app/trips/[id]/rollcall/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { use, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, BellRing } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  Chip,
+  GarmentGlyph,
+  MemberAvatar,
+  SectionLabel,
+} from "@/components/trips/trip-primitives";
+import { useTrip } from "@/hooks/useTrip";
+
+const REQUIRED_SLOTS = ["shirt", "midlayer", "shell", "pants", "gloves"];
+
+export default function RollCallPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { data, loading, error } = useTrip(id);
+  const [poked, setPoked] = useState<Set<string>>(new Set());
+
+  // Use the first day's kits as roll-call snapshot (the "trailhead" moment).
+  const rollCall = useMemo(() => {
+    if (!data || data.days.length === 0) return [];
+    const firstDay = data.days[0];
+    return data.members
+      .filter((m) => m.status !== "left")
+      .map((m) => {
+        const kit = data.kits.find(
+          (k) => k.trip_day_id === firstDay.id && k.trip_member_id === m.id
+        );
+        const items = kit?.items ?? [];
+        const missingRequired = REQUIRED_SLOTS.some((s) => !items.includes(s));
+        const ready = items.length > 0 && !missingRequired && kit?.state !== "warn";
+        return { member: m, items, ready };
+      });
+  }, [data]);
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-2xl flex-col gap-5">
+        <Link
+          href={`/trips/${id}`}
+          className="inline-flex items-center gap-1.5 text-sm text-white/70 hover:text-white"
+        >
+          <ArrowLeft className="size-4" />
+          Trip
+        </Link>
+        <header>
+          <SectionLabel>Departure day</SectionLabel>
+          <h1 className="mt-1 text-[2rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+            Roll call
+          </h1>
+          <p className="mt-1 text-sm text-white/62">Are we leaving? Visual readiness check.</p>
+        </header>
+
+        {loading && <Skeleton className="h-32 w-full rounded-2xl bg-white/12" />}
+        {error && (
+          <div className="rounded-xl border border-orange-400/35 bg-orange-300/10 px-4 py-3 text-sm text-orange-100">
+            {error}
+          </div>
+        )}
+
+        {data && rollCall.length === 0 && (
+          <Card>
+            <p className="text-sm text-white/65">No crew on this trip yet.</p>
+          </Card>
+        )}
+
+        {rollCall.map((row) => (
+          <Card key={row.member.id} highlighted={!row.ready}>
+            <div className="flex flex-wrap items-center gap-3">
+              <span
+                className={
+                  "inline-block size-2.5 shrink-0 rounded-full " +
+                  (row.ready ? "bg-emerald-300" : "bg-orange-300")
+                }
+                aria-hidden
+              />
+              <MemberAvatar name={row.member.display_name} size={32} />
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-white">
+                  {row.member.display_name}
+                </p>
+                <p className="text-xs text-white/55">
+                  {row.ready ? "ready" : "kit incomplete"}
+                </p>
+              </div>
+              <div className="flex items-center gap-1">
+                {row.items.length === 0 ? (
+                  <span className="text-xs text-white/45">no kit</span>
+                ) : (
+                  row.items.slice(0, 6).map((slot) => (
+                    <GarmentGlyph key={slot} kind={slot} />
+                  ))
+                )}
+              </div>
+              <Chip variant={row.ready ? "default" : "warn"}>
+                {row.ready ? "ready" : "missing"}
+              </Chip>
+              {!row.ready && row.member.role !== "organizer" && (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setPoked((s) => {
+                      const next = new Set(s);
+                      next.add(row.member.id);
+                      return next;
+                    })
+                  }
+                  disabled={poked.has(row.member.id)}
+                  className="inline-flex items-center gap-1 rounded-full border border-cyan-300/50 bg-cyan-300/22 px-2.5 py-0.5 text-xs text-white disabled:opacity-60"
+                >
+                  <BellRing className="size-3" />
+                  {poked.has(row.member.id) ? "poked" : "poke"}
+                </button>
+              )}
+            </div>
+          </Card>
+        ))}
+
+        <div className="h-24" />
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/trips/invite/[token]/page.tsx
+++ b/src/app/trips/invite/[token]/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { SignedIn, SignedOut, SignInButton, SignUpButton, useAuth } from "@clerk/nextjs";
+import { CheckCircle2, Loader2, MapPin } from "lucide-react";
+import { toast } from "sonner";
+import PageLayout from "@/components/PageLayout";
+import { Card, SectionLabel, daysBetween, formatDateRange } from "@/components/trips/trip-primitives";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface InvitePreview {
+  invite: { display_name: string; status: string };
+  trip: { id: string; name: string; start_date: string; end_date: string };
+  organizer_name: string | null;
+}
+
+export default function InviteLandingPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = use(params);
+  const router = useRouter();
+  const { isLoaded, userId } = useAuth();
+  const [preview, setPreview] = useState<InvitePreview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [accepting, setAccepting] = useState(false);
+  const returnUrl =
+    typeof window !== "undefined" ? `${window.location.pathname}` : `/trips/invite/${token}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/v1/trips/invite/${token}`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body?.error ?? `Invite unavailable (${res.status})`);
+        }
+        return res.json();
+      })
+      .then((data: InvitePreview) => {
+        if (!cancelled) setPreview(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const accept = async () => {
+    setAccepting(true);
+    try {
+      const res = await fetch(`/api/v1/trips/invite/${token}`, { method: "POST" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Could not accept (${res.status})`);
+      }
+      const data = (await res.json()) as { trip_id: string; already_joined: boolean };
+      toast.success(data.already_joined ? "You were already on this trip" : "You joined the trip");
+      router.push(`/trips/${data.trip_id}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to accept");
+      setAccepting(false);
+    }
+  };
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-md flex-col gap-5">
+        <header>
+          <SectionLabel>Trip invite</SectionLabel>
+          <h1 className="mt-1 text-[2rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+            You&apos;re invited
+          </h1>
+          {preview?.organizer_name && (
+            <p className="mt-1 text-sm text-white/62">
+              {preview.organizer_name} added you as &ldquo;{preview.invite.display_name}&rdquo;.
+            </p>
+          )}
+        </header>
+
+        {error && (
+          <Card>
+            <p className="text-sm text-orange-100">{error}</p>
+            <Link
+              href="/"
+              className="mt-3 inline-flex h-10 items-center justify-center rounded-xl border border-white/14 px-4 text-sm font-medium text-white/85 hover:bg-white/10"
+            >
+              Back home
+            </Link>
+          </Card>
+        )}
+
+        {!preview && !error && <Skeleton className="h-32 w-full rounded-2xl bg-white/12" />}
+
+        {preview && (
+          <>
+            <Card>
+              <div className="flex items-center gap-3">
+                <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-white/14 bg-white/[0.06]">
+                  <MapPin className="size-5 text-white/72" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-base font-semibold text-white/95">
+                    {preview.trip.name}
+                  </p>
+                  <p className="mt-0.5 text-xs text-white/62">
+                    {formatDateRange(preview.trip.start_date, preview.trip.end_date)} ·{" "}
+                    {daysBetween(preview.trip.start_date, preview.trip.end_date)} days
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {!isLoaded ? (
+              <Skeleton className="h-11 w-full rounded-xl bg-white/12" />
+            ) : (
+              <>
+                <SignedIn>
+                  <button
+                    type="button"
+                    onClick={accept}
+                    disabled={accepting}
+                    className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/12 bg-gradient-to-b from-cyan-300/22 to-cyan-300/10 text-sm font-semibold text-white shadow-[0_12px_24px_rgba(0,0,0,0.32)] disabled:opacity-60"
+                  >
+                    {accepting ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <CheckCircle2 className="size-4" />
+                    )}
+                    Accept invitation
+                  </button>
+                  <p className="text-center text-xs text-white/55">
+                    Signed in as <span className="text-white/75">{userId?.slice(0, 6)}…</span>
+                  </p>
+                </SignedIn>
+                <SignedOut>
+                  <div className="flex flex-col gap-2">
+                    <SignInButton mode="modal" forceRedirectUrl={returnUrl}>
+                      <button
+                        type="button"
+                        className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/12 bg-gradient-to-b from-cyan-300/22 to-cyan-300/10 text-sm font-semibold text-white shadow-[0_12px_24px_rgba(0,0,0,0.32)]"
+                      >
+                        Sign in to accept
+                      </button>
+                    </SignInButton>
+                    <SignUpButton mode="modal" forceRedirectUrl={returnUrl}>
+                      <button
+                        type="button"
+                        className="inline-flex h-11 w-full items-center justify-center rounded-xl border border-white/14 text-sm text-white/80 hover:bg-white/10"
+                      >
+                        Or create an account
+                      </button>
+                    </SignUpButton>
+                  </div>
+                </SignedOut>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/trips/new/page.tsx
+++ b/src/app/trips/new/page.tsx
@@ -1,0 +1,809 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, ArrowRight, Calendar as CalIcon, GripVertical, Loader2, MapPin, Plus, UserPlus, X } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+import { Calendar } from "@/components/ui/calendar";
+import { LocationAutocomplete } from "@/components/LocationAutocomplete";
+import { useLocationSearch } from "@/hooks/useLocationSearch";
+import {
+  Card,
+  Chip,
+  InviteLinkButton,
+  MemberAvatar,
+  SectionLabel,
+  daysBetween,
+  formatDateRange,
+} from "@/components/trips/trip-primitives";
+import type { DateRange } from "react-day-picker";
+import type { Trip, TripMember, TripStop } from "@/types/trips";
+import { TRIP_ACTIVITY_OPTIONS } from "@/lib/trip-activities";
+
+type Step = 1 | 2 | 3 | 4;
+
+export default function NewTripPage() {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>(1);
+  const [name, setName] = useState("");
+  const [range, setRange] = useState<DateRange | undefined>(undefined);
+  const [trip, setTrip] = useState<Trip | null>(null);
+  const [stops, setStops] = useState<TripStop[]>([]);
+  const [members, setMembers] = useState<TripMember[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // After we create the trip on step-2 enter, refresh the auto-seeded organizer.
+  useEffect(() => {
+    if (!trip) return;
+    fetch(`/api/v1/trips/${trip.id}`)
+      .then((r) => r.json())
+      .then((data: { members: TripMember[]; stops: TripStop[] }) => {
+        if (data.members) setMembers(data.members);
+        if (data.stops) setStops(data.stops);
+      })
+      .catch(() => {});
+  }, [trip]);
+
+  const createTrip = async () => {
+    if (!range?.from || !range?.to || !name.trim()) {
+      setError("Add a trip name and pick a date range.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/trips", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          start_date: range.from.toISOString().slice(0, 10),
+          end_date: range.to.toISOString().slice(0, 10),
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Failed (${res.status})`);
+      }
+      const data = (await res.json()) as { trip: Trip };
+      setTrip(data.trip);
+      setStep(2);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create trip");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-2xl flex-col gap-5">
+        <StepHeader step={step} />
+        {error && (
+          <div className="rounded-xl border border-orange-400/35 bg-orange-300/10 px-4 py-3 text-sm text-orange-100">
+            {error}
+          </div>
+        )}
+        {step === 1 && (
+          <Step1Dates
+            name={name}
+            onNameChange={setName}
+            range={range}
+            onRangeChange={setRange}
+            submitting={submitting}
+            onNext={createTrip}
+            onBack={() => router.push("/trips")}
+          />
+        )}
+        {step === 2 && trip && (
+          <Step2Stops
+            trip={trip}
+            stops={stops}
+            onStopsChange={setStops}
+            onNext={() => setStep(3)}
+            onBack={() => setStep(1)}
+          />
+        )}
+        {step === 3 && trip && (
+          <Step3Members
+            trip={trip}
+            members={members}
+            onMembersChange={setMembers}
+            onNext={() => setStep(4)}
+            onBack={() => setStep(2)}
+          />
+        )}
+        {step === 4 && trip && (
+          <Step4Review
+            trip={trip}
+            stops={stops}
+            members={members}
+            onBack={() => setStep(3)}
+            onDone={() => router.push(`/trips/${trip.id}`)}
+          />
+        )}
+        <div className="h-24" />
+      </div>
+    </PageLayout>
+  );
+}
+
+function StepHeader({ step }: { step: Step }) {
+  const labels: Record<Step, string> = {
+    1: "Step 1 of 4 · pick dates",
+    2: "Step 2 of 4 · add stops",
+    3: "Step 3 of 4 · invite crew",
+    4: "Step 4 of 4 · review",
+  };
+  const titles: Record<Step, string> = {
+    1: "When?",
+    2: "Where?",
+    3: "Your crew",
+    4: "All set?",
+  };
+  return (
+    <header>
+      <SectionLabel>{labels[step]}</SectionLabel>
+      <h1 className="mt-1 text-[2rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+        {titles[step]}
+      </h1>
+      <div className="mt-3 flex items-center gap-1.5">
+        {[1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            className={
+              "h-1 flex-1 rounded-full " +
+              (i <= step ? "bg-cyan-300/70" : "bg-white/10")
+            }
+          />
+        ))}
+      </div>
+    </header>
+  );
+}
+
+function Step1Dates({
+  name,
+  onNameChange,
+  range,
+  onRangeChange,
+  submitting,
+  onNext,
+  onBack,
+}: {
+  name: string;
+  onNameChange: (v: string) => void;
+  range: DateRange | undefined;
+  onRangeChange: (r: DateRange | undefined) => void;
+  submitting: boolean;
+  onNext: () => void;
+  onBack: () => void;
+}) {
+  const days =
+    range?.from && range?.to
+      ? daysBetween(range.from.toISOString().slice(0, 10), range.to.toISOString().slice(0, 10))
+      : 0;
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <SectionLabel className="mb-2">Trip name</SectionLabel>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder="Whistler Powder"
+          className="w-full rounded-lg border border-white/12 bg-white/[0.06] px-3 py-2.5 text-base text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+        />
+      </Card>
+      <Card>
+        <SectionLabel className="mb-2">Dates</SectionLabel>
+        <p className="mb-3 text-sm text-white/62">Drag across days to pick a range.</p>
+        <div className="rounded-xl border border-white/10 bg-slate-950/30 p-2">
+          <Calendar
+            mode="range"
+            selected={range}
+            onSelect={onRangeChange}
+            numberOfMonths={1}
+            className="bg-transparent text-white"
+          />
+        </div>
+        {range?.from && range?.to && (
+          <div className="mt-3 flex items-center justify-between rounded-lg border border-white/12 bg-white/[0.05] px-3.5 py-2.5">
+            <div>
+              <SectionLabel>Start</SectionLabel>
+              <p className="text-sm font-semibold text-white">
+                {range.from.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+              </p>
+            </div>
+            <ArrowRight className="size-4 text-white/55" />
+            <div>
+              <SectionLabel>End</SectionLabel>
+              <p className="text-sm font-semibold text-white">
+                {range.to.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+              </p>
+            </div>
+            <Chip variant="accent">{days} day{days === 1 ? "" : "s"}</Chip>
+          </div>
+        )}
+      </Card>
+      <NavBar
+        onBack={onBack}
+        backLabel="Cancel"
+        onNext={onNext}
+        nextLabel={submitting ? "Saving…" : "Next"}
+        nextDisabled={submitting || !name.trim() || !range?.from || !range?.to}
+        nextLoading={submitting}
+      />
+    </div>
+  );
+}
+
+function Step2Stops({
+  trip,
+  stops,
+  onStopsChange,
+  onNext,
+  onBack,
+}: {
+  trip: Trip;
+  stops: TripStop[];
+  onStopsChange: (stops: TripStop[]) => void;
+  onNext: () => void;
+  onBack: () => void;
+}) {
+  const [editing, setEditing] = useState<TripStop | null>(null);
+  const [adding, setAdding] = useState(false);
+  const search = useLocationSearch();
+
+  const addStop = async () => {
+    const selected = search.selectedLocation;
+    if (!selected) return;
+    setAdding(true);
+    try {
+      const res = await fetch(`/api/v1/trips/${trip.id}/stops`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: selected.region
+            ? `${selected.name}, ${selected.region}`
+            : `${selected.name}, ${selected.country}`,
+          latitude: selected.latitude,
+          longitude: selected.longitude,
+          activities: [],
+        }),
+      });
+      const data = (await res.json()) as { stop?: TripStop };
+      if (data.stop) onStopsChange([...stops, data.stop]);
+      search.reset();
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const removeStop = async (stopId: string) => {
+    await fetch(`/api/v1/trips/${trip.id}/stops/${stopId}`, { method: "DELETE" });
+    onStopsChange(stops.filter((s) => s.id !== stopId));
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <SectionLabel className="mb-2">Add a stop</SectionLabel>
+        <LocationAutocomplete
+          id="trip-stop-search"
+          placeholder="Search a city or place…"
+          location={search.location}
+          locationQuery={search.locationQuery}
+          suggestions={search.suggestions}
+          showSuggestions={search.showSuggestions}
+          selectedLocation={search.selectedLocation}
+          isSearching={search.isSearching}
+          suggestionRef={search.suggestionRef}
+          onLocationInputChange={search.handleLocationInputChange}
+          onLocationFocus={() =>
+            search.suggestions.length > 0 && search.setShowSuggestions(true)
+          }
+          onSelectLocation={search.handleSelectLocation}
+          onDismiss={search.dismiss}
+        />
+        <button
+          type="button"
+          onClick={addStop}
+          disabled={!search.selectedLocation || adding}
+          className="mt-3 inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-white/14 bg-white/[0.08] px-4 text-sm font-medium text-white disabled:opacity-50"
+        >
+          {adding ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+          Add stop
+        </button>
+      </Card>
+
+      {stops.length > 0 && (
+        <Card>
+          <SectionLabel className="mb-2">Trip stops</SectionLabel>
+          <div className="flex flex-col gap-2">
+            {stops.map((stop, i) => (
+              <div
+                key={stop.id}
+                className="flex items-center gap-2 rounded-lg border border-white/10 bg-white/[0.05] px-3 py-2.5"
+              >
+                <GripVertical className="size-4 text-white/40" />
+                <span className="flex size-6 shrink-0 items-center justify-center rounded-full border border-white/22 text-[11px] font-semibold text-white">
+                  {i + 1}
+                </span>
+                <MapPin className="size-4 text-white/65" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-white">{stop.name}</p>
+                  <p className="text-xs text-white/55">
+                    {stop.activities.length === 0
+                      ? "no activities yet"
+                      : stop.activities.join(", ")}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setEditing(stop)}
+                  className="rounded-md border border-white/14 px-2 py-1 text-xs text-white/75 hover:bg-white/10"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => removeStop(stop.id)}
+                  aria-label="Remove stop"
+                  className="rounded-md p-1 text-white/55 hover:bg-white/10 hover:text-white"
+                >
+                  <X className="size-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+
+      <NavBar
+        onBack={onBack}
+        onNext={onNext}
+        nextLabel="Next"
+        nextDisabled={stops.length === 0}
+      />
+
+      {editing && (
+        <StopDetailSheet
+          tripId={trip.id}
+          stop={editing}
+          tripStart={trip.start_date}
+          tripEnd={trip.end_date}
+          onClose={() => setEditing(null)}
+          onSaved={(updated) => {
+            onStopsChange(stops.map((s) => (s.id === updated.id ? updated : s)));
+            setEditing(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function StopDetailSheet({
+  tripId,
+  stop,
+  tripStart,
+  tripEnd,
+  onClose,
+  onSaved,
+}: {
+  tripId: string;
+  stop: TripStop;
+  tripStart: string;
+  tripEnd: string;
+  onClose: () => void;
+  onSaved: (s: TripStop) => void;
+}) {
+  const [activities, setActivities] = useState<string[]>(stop.activities);
+  const [selectedDates, setSelectedDates] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !saving) onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, saving]);
+
+  // Enumerate dates inline (avoids importing server lib into client bundle).
+  const tripDates: string[] = (() => {
+    const out: string[] = [];
+    for (
+      let d = new Date(`${tripStart}T00:00:00Z`);
+      d <= new Date(`${tripEnd}T00:00:00Z`);
+      d = new Date(d.getTime() + 86400000)
+    ) {
+      out.push(d.toISOString().slice(0, 10));
+    }
+    return out;
+  })();
+
+  const toggleActivity = (a: string) =>
+    setActivities((curr) =>
+      curr.includes(a) ? curr.filter((x) => x !== a) : [...curr, a]
+    );
+  const toggleDate = (iso: string) =>
+    setSelectedDates((curr) =>
+      curr.includes(iso) ? curr.filter((d) => d !== iso) : [...curr, iso]
+    );
+
+  const save = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/v1/trips/${tripId}/stops/${stop.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ activities, day_dates: selectedDates }),
+      });
+      const data = (await res.json()) as { stop?: TripStop };
+      if (data.stop) onSaved(data.stop);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Edit stop ${stop.name}`}
+      onClick={() => !saving && onClose()}
+      className="fixed inset-0 z-50 flex items-end justify-center overflow-y-auto bg-black/55 backdrop-blur-sm sm:items-center"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-2xl rounded-t-3xl border-t border-white/14 bg-slate-950/95 px-5 pt-4 shadow-[0_-12px_40px_rgba(0,0,0,0.5)] pb-[calc(env(safe-area-inset-bottom)+5.5rem)] sm:rounded-3xl sm:pb-6"
+      >
+        <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-white/22" />
+        <div className="flex items-center justify-between">
+          <div>
+            <SectionLabel>Stop detail</SectionLabel>
+            <p className="text-base font-semibold text-white">{stop.name}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-white/55 hover:bg-white/10"
+            aria-label="Close"
+          >
+            <X className="size-5" />
+          </button>
+        </div>
+
+        <div className="mt-4">
+          <SectionLabel>Which days at this stop?</SectionLabel>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {tripDates.map((iso) => {
+              const date = new Date(`${iso}T00:00:00`);
+              const dow = date.toLocaleDateString(undefined, { weekday: "short" });
+              const day = date.getDate();
+              const on = selectedDates.includes(iso);
+              return (
+                <button
+                  key={iso}
+                  type="button"
+                  onClick={() => toggleDate(iso)}
+                  className={
+                    "flex w-14 flex-col items-center rounded-lg border px-2 py-1.5 text-center text-xs transition-colors " +
+                    (on
+                      ? "border-cyan-300/55 bg-cyan-300/15 text-white"
+                      : "border-white/14 bg-white/[0.05] text-white/72")
+                  }
+                >
+                  <span className="text-[10px] uppercase tracking-wide text-white/55">{dow}</span>
+                  <span className="text-base font-semibold leading-none">{day}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <SectionLabel>Activities at this stop</SectionLabel>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {TRIP_ACTIVITY_OPTIONS.map((a) => {
+              const on = activities.includes(a);
+              return (
+                <button
+                  key={a}
+                  type="button"
+                  onClick={() => toggleActivity(a)}
+                  className={
+                    "rounded-full border px-3 py-1 text-xs " +
+                    (on
+                      ? "border-cyan-300/55 bg-cyan-300/22 text-white"
+                      : "border-white/16 bg-white/[0.05] text-white/72")
+                  }
+                >
+                  {a}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving}
+          className="mt-5 inline-flex h-11 w-full items-center justify-center gap-2 rounded-xl border border-white/12 bg-cyan-300/22 text-sm font-semibold text-white"
+        >
+          {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+          Save stop
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Step3Members({
+  trip,
+  members,
+  onMembersChange,
+  onNext,
+  onBack,
+}: {
+  trip: Trip;
+  members: TripMember[];
+  onMembersChange: (m: TripMember[]) => void;
+  onNext: () => void;
+  onBack: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [kind, setKind] = useState<"invite" | "guest">("invite");
+  const [adding, setAdding] = useState(false);
+
+  const add = async () => {
+    if (!name.trim()) return;
+    setAdding(true);
+    try {
+      const res = await fetch(`/api/v1/trips/${trip.id}/members`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ display_name: name.trim(), kind }),
+      });
+      const data = (await res.json()) as { member?: TripMember };
+      if (data.member) onMembersChange([...members, data.member]);
+      setName("");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const remove = async (memberId: string) => {
+    await fetch(`/api/v1/trips/${trip.id}/members/${memberId}`, { method: "DELETE" });
+    onMembersChange(members.filter((m) => m.id !== memberId));
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <SectionLabel className="mb-2">On the trip</SectionLabel>
+        <p className="text-xs text-white/55">Solo? You can skip this step.</p>
+        <div className="mt-3 flex flex-col gap-2">
+          {members.map((m) => (
+            <MemberRow
+              key={m.id}
+              member={m}
+              tripName={trip.name}
+              onRemove={m.role === "organizer" ? undefined : () => remove(m.id)}
+            />
+          ))}
+        </div>
+      </Card>
+
+      <Card>
+        <SectionLabel className="mb-2">Add someone</SectionLabel>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Display name"
+            className="h-10 flex-1 rounded-lg border border-white/12 bg-white/[0.06] px-3 text-sm text-white placeholder:text-white/40 focus:border-white/30 focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={add}
+            disabled={!name.trim() || adding}
+            className="inline-flex h-10 items-center gap-1.5 rounded-lg border border-white/14 bg-white/[0.08] px-3 text-sm font-medium text-white disabled:opacity-50"
+          >
+            {adding ? <Loader2 className="size-4 animate-spin" /> : <UserPlus className="size-4" />}
+            Add
+          </button>
+        </div>
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            onClick={() => setKind("invite")}
+            className={
+              "flex-1 rounded-lg border px-3 py-2 text-xs font-medium transition-colors " +
+              (kind === "invite"
+                ? "border-cyan-300/55 bg-cyan-300/15 text-white"
+                : "border-white/14 bg-white/[0.05] text-white/72")
+            }
+          >
+            Share link · they make an account
+          </button>
+          <button
+            type="button"
+            onClick={() => setKind("guest")}
+            className={
+              "flex-1 rounded-lg border px-3 py-2 text-xs font-medium transition-colors " +
+              (kind === "guest"
+                ? "border-cyan-300/55 bg-cyan-300/15 text-white"
+                : "border-white/14 bg-white/[0.05] text-white/72")
+            }
+          >
+            Guest · no signup, uses generics
+          </button>
+        </div>
+      </Card>
+
+      <NavBar onBack={onBack} onNext={onNext} nextLabel="Next" nextDisabled={false} />
+    </div>
+  );
+}
+
+function MemberRow({
+  member,
+  onRemove,
+  tripName,
+}: {
+  member: TripMember;
+  onRemove?: () => void;
+  tripName?: string;
+}) {
+  const state: "default" | "guest" | "invited" | "self" =
+    member.role === "organizer"
+      ? "self"
+      : member.status === "guest"
+      ? "guest"
+      : member.status === "invited"
+      ? "invited"
+      : "default";
+  const sub =
+    member.role === "organizer"
+      ? "organizer"
+      : member.status === "guest"
+      ? "guest · using generics"
+      : member.status === "invited"
+      ? "invited · pending"
+      : "joined";
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/[0.04] px-3 py-2.5">
+      <MemberAvatar name={member.display_name} state={state} />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-white">{member.display_name}</p>
+        <p className="text-xs text-white/55">{sub}</p>
+      </div>
+      {member.status === "invited" && member.invite_token && (
+        <InviteLinkButton
+          token={member.invite_token}
+          recipientName={member.display_name}
+          tripName={tripName}
+        />
+      )}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="rounded-md p-1 text-white/55 hover:bg-white/10 hover:text-white"
+          aria-label="Remove member"
+        >
+          <X className="size-4" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function Step4Review({
+  trip,
+  stops,
+  members,
+  onBack,
+  onDone,
+}: {
+  trip: Trip;
+  stops: TripStop[];
+  members: TripMember[];
+  onBack: () => void;
+  onDone: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <SectionLabel>Trip</SectionLabel>
+        <p className="mt-1 text-base font-semibold text-white">{trip.name}</p>
+        <p className="mt-0.5 text-sm text-white/65">
+          <CalIcon className="mr-1 inline size-3.5" />
+          {formatDateRange(trip.start_date, trip.end_date)} ·{" "}
+          {daysBetween(trip.start_date, trip.end_date)} days
+        </p>
+      </Card>
+      <Card>
+        <SectionLabel>Stops ({stops.length})</SectionLabel>
+        {stops.length === 0 ? (
+          <p className="mt-2 text-sm text-white/55">No stops yet.</p>
+        ) : (
+          <ul className="mt-2 flex flex-col gap-1.5">
+            {stops.map((s, i) => (
+              <li key={s.id} className="flex items-center gap-2 text-sm text-white/85">
+                <span className="text-xs text-white/45">{i + 1}.</span>
+                <MapPin className="size-3.5 text-white/55" />
+                {s.name}
+                {s.activities.length > 0 && (
+                  <span className="text-xs text-white/55">· {s.activities.join(", ")}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+      <Card>
+        <SectionLabel>Crew ({members.length})</SectionLabel>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {members.map((m) => (
+            <div key={m.id} className="flex items-center gap-1.5">
+              <MemberAvatar
+                name={m.display_name}
+                state={m.role === "organizer" ? "self" : "default"}
+                size={28}
+              />
+              <span className="text-sm text-white/80">{m.display_name}</span>
+            </div>
+          ))}
+        </div>
+      </Card>
+      <NavBar onBack={onBack} onNext={onDone} nextLabel="Open trip" />
+    </div>
+  );
+}
+
+function NavBar({
+  onBack,
+  backLabel = "Back",
+  onNext,
+  nextLabel,
+  nextDisabled = false,
+  nextLoading = false,
+}: {
+  onBack: () => void;
+  backLabel?: string;
+  onNext: () => void;
+  nextLabel: string;
+  nextDisabled?: boolean;
+  nextLoading?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        onClick={onBack}
+        className="inline-flex h-11 items-center gap-1.5 rounded-xl border border-white/14 px-4 text-sm font-medium text-white/85 hover:bg-white/10"
+      >
+        <ArrowLeft className="size-4" />
+        {backLabel}
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={nextDisabled}
+        className="ml-auto inline-flex h-11 min-w-32 items-center justify-center gap-1.5 rounded-xl border border-white/14 bg-gradient-to-b from-cyan-300/22 to-cyan-300/10 px-4 text-sm font-semibold text-white shadow-[0_10px_22px_rgba(0,0,0,0.32)] disabled:opacity-50"
+      >
+        {nextLoading ? <Loader2 className="size-4 animate-spin" /> : null}
+        {nextLabel}
+        <ArrowRight className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/app/trips/page.tsx
+++ b/src/app/trips/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Loader2, MapPin, Plus, Users } from "lucide-react";
+import PageLayout from "@/components/PageLayout";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  Chip,
+  MemberAvatar,
+  SectionLabel,
+  formatDateRange,
+  daysBetween,
+} from "@/components/trips/trip-primitives";
+import type { TripSummary } from "@/types/trips";
+
+const STATUS_LABEL: Record<TripSummary["status"], string> = {
+  planning: "planning",
+  next_up: "next up",
+  live: "live",
+  past: "past",
+};
+
+export default function TripsHomePage() {
+  const [trips, setTrips] = useState<TripSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/v1/trips")
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`Failed (${res.status})`);
+        return res.json();
+      })
+      .then((data: { trips: TripSummary[] }) => {
+        if (!cancelled) setTrips(data.trips);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown error");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const grouped = useMemo(() => {
+    if (!trips) return { upcoming: [], past: [] };
+    return {
+      upcoming: trips.filter((t) => t.status !== "past"),
+      past: trips.filter((t) => t.status === "past"),
+    };
+  }, [trips]);
+
+  return (
+    <PageLayout chromeVariant="compact">
+      <div className="flex w-full max-w-3xl flex-col gap-5">
+        <header>
+          <SectionLabel>Your trips</SectionLabel>
+          <h1 className="mt-1 text-[2.25rem] font-semibold leading-tight tracking-[-0.04em] text-white/94">
+            Trips
+          </h1>
+          <p className="mt-1 text-sm text-white/62">
+            Pick a trip to plan kits, manage your crew, and pack faster.
+          </p>
+        </header>
+
+        <Link
+          href="/trips/new"
+          className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/12 bg-gradient-to-b from-cyan-300/22 to-cyan-300/10 text-sm font-semibold text-white shadow-[0_12px_24px_rgba(0,0,0,0.32)] transition-colors hover:bg-cyan-300/16"
+        >
+          <Plus className="size-4" />
+          New trip
+        </Link>
+
+        {error && (
+          <div className="rounded-xl border border-orange-400/35 bg-orange-300/10 px-4 py-3 text-sm text-orange-100">
+            {error}
+          </div>
+        )}
+
+        {trips === null && !error ? (
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-24 w-full rounded-2xl bg-white/12" />
+            <Skeleton className="h-24 w-full rounded-2xl bg-white/12" />
+            <Skeleton className="h-24 w-full rounded-2xl bg-white/12" />
+          </div>
+        ) : trips && trips.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-white/22 bg-white/[0.04] px-5 py-10 text-center">
+            <Loader2 className="mx-auto mb-3 size-8 text-white/35" />
+            <p className="text-base font-medium text-white/85">No trips yet</p>
+            <p className="mt-1 text-sm text-white/60">
+              A trip can be solo or shared. Tap “New trip” to get started.
+            </p>
+          </div>
+        ) : (
+          <>
+            {grouped.upcoming.length > 0 && (
+              <section className="flex flex-col gap-2.5">
+                <SectionLabel>Upcoming</SectionLabel>
+                {grouped.upcoming.map((trip, i) => (
+                  <TripRow key={trip.id} trip={trip} highlighted={i === 0} />
+                ))}
+              </section>
+            )}
+            {grouped.past.length > 0 && (
+              <section className="flex flex-col gap-2.5">
+                <SectionLabel>Past</SectionLabel>
+                {grouped.past.map((trip) => (
+                  <TripRow key={trip.id} trip={trip} />
+                ))}
+              </section>
+            )}
+          </>
+        )}
+
+        {/* Spacer for mobile tab bar */}
+        <div className="h-24" />
+      </div>
+    </PageLayout>
+  );
+}
+
+function TripRow({ trip, highlighted = false }: { trip: TripSummary; highlighted?: boolean }) {
+  const total = daysBetween(trip.start_date, trip.end_date);
+  return (
+    <Link href={`/trips/${trip.id}`} className="block">
+      <Card highlighted={highlighted}>
+        <div className="flex items-center gap-3">
+          <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-white/14 bg-white/[0.06]">
+            <MapPin className="size-5 text-white/72" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-base font-semibold text-white/95">{trip.name}</p>
+            <p className="mt-0.5 text-xs text-white/62">
+              {formatDateRange(trip.start_date, trip.end_date)} · {total}{" "}
+              {total === 1 ? "day" : "days"} · {trip.member_count}{" "}
+              {trip.member_count === 1 ? "person" : "people"}
+            </p>
+            <div className="mt-2 flex items-center gap-2">
+              <Chip variant={highlighted ? "accent" : "outline"}>{STATUS_LABEL[trip.status]}</Chip>
+              {trip.stop_count > 0 && (
+                <Chip variant="outline">
+                  <Users className="size-3" /> {trip.stop_count} stop
+                  {trip.stop_count === 1 ? "" : "s"}
+                </Chip>
+              )}
+            </div>
+          </div>
+        </div>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/AppNavigation.test.tsx
+++ b/src/components/AppNavigation.test.tsx
@@ -57,14 +57,26 @@ describe("AppNavigation", () => {
       mockPathname = "/trips";
       renderBothNavs();
       const trips = screen.getAllByRole("link", { name: /trips/i });
-      // Both mobile and desktop variants render — at least one should be marked active
       expect(trips.length).toBeGreaterThan(0);
+      expect(trips.some((el) => el.getAttribute("aria-current") === "page")).toBe(true);
+      const wardrobe = screen.getAllByRole("link", { name: /wardrobe/i });
+      expect(wardrobe.every((el) => el.getAttribute("aria-current") !== "page")).toBe(true);
     });
 
     it("marks Trips active on nested trip routes", () => {
       mockPathname = "/trips/abc-123";
       renderBothNavs();
-      expect(screen.getAllByText("Trips").length).toBeGreaterThan(0);
+      const trips = screen.getAllByRole("link", { name: /trips/i });
+      expect(trips.some((el) => el.getAttribute("aria-current") === "page")).toBe(true);
+    });
+
+    it("marks Wardrobe active on /wardrobe", () => {
+      mockPathname = "/wardrobe";
+      renderBothNavs();
+      const wardrobe = screen.getAllByRole("link", { name: /wardrobe/i });
+      expect(wardrobe.some((el) => el.getAttribute("aria-current") === "page")).toBe(true);
+      const trips = screen.getAllByRole("link", { name: /trips/i });
+      expect(trips.every((el) => el.getAttribute("aria-current") !== "page")).toBe(true);
     });
   });
 });

--- a/src/components/AppNavigation.test.tsx
+++ b/src/components/AppNavigation.test.tsx
@@ -1,14 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { MobileTabBar, DesktopActionDock } from "./AppNavigation";
 
 let mockPathname = "/";
-const mockPush = vi.fn();
 
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
-  useRouter: () => ({ push: mockPush, replace: vi.fn(), prefetch: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
 }));
 
 const localStorageMock = {
@@ -36,10 +34,15 @@ describe("AppNavigation", () => {
   });
 
   describe("rendering", () => {
-    it("renders Plan and Wardrobe tabs in both navs", () => {
+    it("renders Trips and Wardrobe tabs in both navs", () => {
       renderBothNavs();
-      expect(screen.getAllByText("Plan")).toHaveLength(2);
+      expect(screen.getAllByText("Trips")).toHaveLength(2);
       expect(screen.getAllByText("Wardrobe")).toHaveLength(2);
+    });
+
+    it("does not render a Plan tab", () => {
+      renderBothNavs();
+      expect(screen.queryAllByText("Plan")).toHaveLength(0);
     });
 
     it("does not render a Gear Up button in either nav", () => {
@@ -49,40 +52,19 @@ describe("AppNavigation", () => {
     });
   });
 
-  describe("Plan tab parity", () => {
-    it("both Plan tabs dispatch navigatePlanAhead on home page", async () => {
-      const spy = vi.fn();
-      window.addEventListener("navigatePlanAhead", spy);
-
-      const user = userEvent.setup();
+  describe("Trips tab active state", () => {
+    it("marks Trips active on /trips", () => {
+      mockPathname = "/trips";
       renderBothNavs();
-
-      const planLinks = screen.getAllByText("Plan");
-      await user.click(planLinks[0]);
-      await user.click(planLinks[1]);
-
-      expect(spy).toHaveBeenCalledTimes(2);
-      // Already on home — should NOT router.push
-      expect(mockPush).not.toHaveBeenCalled();
-
-      window.removeEventListener("navigatePlanAhead", spy);
+      const trips = screen.getAllByRole("link", { name: /trips/i });
+      // Both mobile and desktop variants render — at least one should be marked active
+      expect(trips.length).toBeGreaterThan(0);
     });
 
-    it("Plan tab navigates when not on home page", async () => {
-      mockPathname = "/wardrobe";
-      const spy = vi.fn();
-      window.addEventListener("navigatePlanAhead", spy);
-
-      const user = userEvent.setup();
+    it("marks Trips active on nested trip routes", () => {
+      mockPathname = "/trips/abc-123";
       renderBothNavs();
-
-      const planLinks = screen.getAllByText("Plan");
-      await user.click(planLinks[0]);
-
-      expect(spy).toHaveBeenCalledTimes(1);
-      expect(mockPush).toHaveBeenCalledWith("/?mode=planAhead");
-
-      window.removeEventListener("navigatePlanAhead", spy);
+      expect(screen.getAllByText("Trips").length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -38,6 +38,7 @@ export function MobileTabBar() {
       <Link
         key={item.href}
         href={item.href}
+        aria-current={isActive ? "page" : undefined}
         className={cn(
           "flex flex-col items-center gap-1 text-[11px] font-medium leading-none tracking-[0.01em] transition-colors",
           isActive ? "text-white" : "text-white/70",
@@ -93,6 +94,7 @@ export function DesktopActionDock() {
       <Link
         key={item.href}
         href={item.href}
+        aria-current={isActive ? "page" : undefined}
         className={cn(
           "inline-flex h-10 min-w-[102px] items-center justify-center gap-2 rounded-xl border px-3.5 text-sm font-semibold transition-colors",
           isActive

--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -2,55 +2,34 @@
 
 import { useCallback } from "react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
-import { CalendarDays, Shirt } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { Map, Shirt } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useNativeTabShell } from "@/hooks/useNativeTabShell";
 
 const TAB_ITEMS = [
-  { href: "/?mode=planAhead", label: "Plan", icon: CalendarDays },
+  { href: "/trips", label: "Trips", icon: Map },
   { href: "/wardrobe", label: "Wardrobe", icon: Shirt },
 ];
 
 type TabItem = (typeof TAB_ITEMS)[number];
 
-interface RouterLike {
-  push: (href: string) => void;
-}
-
-function useNavigationState(pathname: string, router: RouterLike) {
+function useNavigationState(pathname: string) {
   const isLandingScreen = pathname === "/";
 
   const isTabActive = useCallback(
-    (href: string) => (href.startsWith("/?") ? pathname === "/" : pathname === href),
+    (href: string) =>
+      href === "/trips" ? pathname.startsWith("/trips") : pathname === href,
     [pathname]
   );
 
-  const onTabClick = useCallback(
-    (item: TabItem, e: React.MouseEvent) => {
-      if (item.href === "/?mode=planAhead") {
-        e.preventDefault();
-        window.dispatchEvent(new CustomEvent("navigatePlanAhead"));
-        if (pathname !== "/") {
-          router.push(item.href);
-        }
-      }
-    },
-    [pathname, router]
-  );
-
-  return {
-    isLandingScreen,
-    isTabActive,
-    onTabClick,
-  };
+  return { isLandingScreen, isTabActive };
 }
 
 export function MobileTabBar() {
   const isNativeTabShell = useNativeTabShell();
   const pathname = usePathname();
-  const router = useRouter();
-  const { isLandingScreen, isTabActive, onTabClick } = useNavigationState(pathname, router);
+  const { isLandingScreen, isTabActive } = useNavigationState(pathname);
 
   const renderTab = (item: TabItem) => {
     const isActive = isTabActive(item.href);
@@ -59,7 +38,6 @@ export function MobileTabBar() {
       <Link
         key={item.href}
         href={item.href}
-        onClick={(e) => onTabClick(item, e)}
         className={cn(
           "flex flex-col items-center gap-1 text-[11px] font-medium leading-none tracking-[0.01em] transition-colors",
           isActive ? "text-white" : "text-white/70",
@@ -96,8 +74,7 @@ export function MobileTabBar() {
     >
       <div className="h-[64px] border-t border-white/20 bg-[rgba(17,45,62,0.74)] backdrop-blur-2xl">
         <div className="flex h-full items-center justify-around px-6 pb-1 pt-1.5">
-          {renderTab(TAB_ITEMS[0])}
-          {renderTab(TAB_ITEMS[1])}
+          {TAB_ITEMS.map(renderTab)}
         </div>
       </div>
     </nav>
@@ -107,8 +84,7 @@ export function MobileTabBar() {
 export function DesktopActionDock() {
   const isNativeTabShell = useNativeTabShell();
   const pathname = usePathname();
-  const router = useRouter();
-  const { isLandingScreen, isTabActive, onTabClick } = useNavigationState(pathname, router);
+  const { isLandingScreen, isTabActive } = useNavigationState(pathname);
 
   const renderDesktopTab = (item: TabItem) => {
     const isActive = isTabActive(item.href);
@@ -117,7 +93,6 @@ export function DesktopActionDock() {
       <Link
         key={item.href}
         href={item.href}
-        onClick={(e) => onTabClick(item, e)}
         className={cn(
           "inline-flex h-10 min-w-[102px] items-center justify-center gap-2 rounded-xl border px-3.5 text-sm font-semibold transition-colors",
           isActive
@@ -145,8 +120,7 @@ export function DesktopActionDock() {
       )}
     >
       <div className="pointer-events-auto inline-flex max-w-[min(640px,calc(100vw-var(--sidebar-width)-2.25rem))] items-center gap-2 rounded-2xl border border-white/25 bg-[linear-gradient(135deg,rgba(54,86,116,0.8)_0%,rgba(38,86,108,0.78)_100%)] p-2 shadow-[0_18px_34px_rgba(0,0,0,0.3)] backdrop-blur-xl">
-        {renderDesktopTab(TAB_ITEMS[0])}
-        {renderDesktopTab(TAB_ITEMS[1])}
+        {TAB_ITEMS.map(renderDesktopTab)}
       </div>
     </nav>
   );

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { CalendarDays, Shirt, Settings, HelpCircle, MessageSquare } from "lucide-react";
+import { Map, Shirt, Settings, HelpCircle, MessageSquare } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -20,7 +20,7 @@ import { PreferencesDrawer } from "@/components/PreferencesDrawer";
 import { usePreferences } from "@/hooks/usePreferences";
 
 const NAV_ITEMS = [
-  { href: "/?mode=planAhead", label: "Plan", icon: CalendarDays },
+  { href: "/trips", label: "Trips", icon: Map },
   { href: "/wardrobe", label: "Wardrobe", icon: Shirt },
 ];
 
@@ -79,7 +79,11 @@ export function AppSidebar() {
                 <SidebarMenuItem key={item.href}>
                   <SidebarMenuButton
                     asChild
-                    isActive={item.href.startsWith("/?") ? pathname === "/" : pathname === item.href}
+                    isActive={
+                      item.href === "/trips"
+                        ? pathname.startsWith("/trips")
+                        : pathname === item.href
+                    }
                     tooltip={item.label}
                     className="rounded-lg data-[active=true]:bg-slate-200/90 data-[active=true]:text-slate-900"
                   >

--- a/src/components/trips/trip-primitives.tsx
+++ b/src/components/trips/trip-primitives.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { ReactNode } from "react";
+import {
+  CloudRain,
+  CloudSnow,
+  Cloud,
+  Sun,
+  Snowflake,
+  CloudSun,
+  Shirt,
+  Footprints,
+  Hand,
+  Copy,
+  Share2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+const WEATHER_ICONS: Record<string, typeof Sun> = {
+  snow: Snowflake,
+  rain: CloudRain,
+  cloud: Cloud,
+  mix: CloudSnow,
+  sun: Sun,
+  partly: CloudSun,
+};
+
+export function WeatherGlyph({ kind, className }: { kind: string; className?: string }) {
+  const Icon = WEATHER_ICONS[kind] ?? Cloud;
+  return <Icon className={cn("size-5 text-white/80", className)} />;
+}
+
+const GARMENT_ICONS: Record<string, typeof Shirt> = {
+  shirt: Shirt,
+  midlayer: Shirt,
+  jacket: Shirt,
+  shell: Shirt,
+  pants: Footprints,
+  gloves: Hand,
+};
+
+export function GarmentGlyph({ kind, className }: { kind: string; className?: string }) {
+  const Icon = GARMENT_ICONS[kind] ?? Shirt;
+  return <Icon className={cn("size-4 text-white/72", className)} />;
+}
+
+export function MemberAvatar({
+  name,
+  highlighted = false,
+  size = 32,
+  state = "default",
+}: {
+  name: string;
+  highlighted?: boolean;
+  size?: number;
+  state?: "default" | "guest" | "invited" | "self";
+}) {
+  const stateStyles = {
+    default: "border-white/45 bg-white/12 text-white",
+    guest: "border-white/30 bg-white/[0.06] text-white/70",
+    invited: "border-dashed border-white/35 bg-transparent text-white/70",
+    self: "border-cyan-300/60 bg-cyan-300/22 text-white",
+  };
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full border font-semibold uppercase tracking-tight",
+        highlighted && "ring-2 ring-cyan-300/50",
+        stateStyles[state]
+      )}
+      style={{ width: size, height: size, fontSize: Math.round(size * 0.4) }}
+    >
+      {name.slice(0, 1)}
+    </span>
+  );
+}
+
+export function Chip({
+  children,
+  variant = "default",
+  className,
+}: {
+  children: ReactNode;
+  variant?: "default" | "accent" | "warn" | "outline";
+  className?: string;
+}) {
+  const styles = {
+    default: "border-white/22 bg-white/10 text-white/85",
+    accent: "border-cyan-300/50 bg-cyan-300/22 text-cyan-50",
+    warn: "border-orange-300/45 bg-orange-300/18 text-orange-50",
+    outline: "border-white/22 bg-transparent text-white/72",
+  };
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-[11px] font-medium",
+        styles[variant],
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function Card({
+  children,
+  className,
+  highlighted = false,
+}: {
+  children: ReactNode;
+  className?: string;
+  highlighted?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border bg-slate-950/22 px-4 py-3.5 backdrop-blur-sm transition-colors",
+        highlighted
+          ? "border-cyan-300/55 bg-cyan-300/[0.08]"
+          : "border-white/12 hover:border-white/20",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function SectionLabel({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <p
+      className={cn(
+        "text-[10px] font-semibold uppercase tracking-[0.18em] text-white/45",
+        className
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+export function Spine({ color = "cyan" }: { color?: "cyan" | "emerald" | "amber" }) {
+  const cls = {
+    cyan: "bg-cyan-300/70",
+    emerald: "bg-emerald-300/70",
+    amber: "bg-amber-300/70",
+  }[color];
+  return <span className={cn("inline-block w-[3px] self-stretch rounded-full", cls)} />;
+}
+
+export function inferWeatherKind(tempF: number, precipFraction: number): string {
+  if (precipFraction > 0.5) return tempF <= 32 ? "snow" : "rain";
+  if (precipFraction > 0.1) return "mix";
+  if (tempF <= 27) return "snow";
+  if (tempF >= 59) return "sun";
+  return "cloud";
+}
+
+export function formatDateRange(startISO: string, endISO: string): string {
+  const fmt = (iso: string) =>
+    new Date(`${iso}T00:00:00`).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+  if (startISO === endISO) return fmt(startISO);
+  return `${fmt(startISO)} – ${fmt(endISO)}`;
+}
+
+export function daysBetween(startISO: string, endISO: string): number {
+  const start = new Date(`${startISO}T00:00:00Z`).getTime();
+  const end = new Date(`${endISO}T00:00:00Z`).getTime();
+  return Math.round((end - start) / 86400000) + 1;
+}
+
+export function buildInviteUrl(token: string): string {
+  if (typeof window === "undefined") return `/trips/invite/${token}`;
+  return `${window.location.origin}/trips/invite/${token}`;
+}
+
+export function InviteLinkButton({
+  token,
+  recipientName,
+  tripName,
+  className,
+}: {
+  token: string;
+  recipientName: string;
+  tripName?: string;
+  className?: string;
+}) {
+  const handleShare = async () => {
+    const url = buildInviteUrl(token);
+    const shareData: ShareData = {
+      title: tripName ? `${tripName} — trip invite` : "Trip invite",
+      text: `${recipientName}, here's your invite to ${tripName ?? "the trip"}.`,
+      url,
+    };
+    const canNativeShare =
+      typeof navigator !== "undefined" &&
+      typeof navigator.share === "function" &&
+      (typeof navigator.canShare !== "function" || navigator.canShare(shareData));
+
+    if (canNativeShare) {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch (err) {
+        // User cancelled — fall through to clipboard.
+        if (err instanceof Error && err.name === "AbortError") return;
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success("Invite link copied");
+    } catch {
+      // Final fallback — show the URL so the user can copy manually.
+      window.prompt("Copy this invite link:", url);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md border border-cyan-300/45 bg-cyan-300/15 px-2.5 py-1.5 text-xs font-medium text-cyan-50 hover:bg-cyan-300/25",
+        className
+      )}
+    >
+      {typeof navigator !== "undefined" && typeof navigator.share === "function" ? (
+        <Share2 className="size-3.5" />
+      ) : (
+        <Copy className="size-3.5" />
+      )}
+      Send invite
+    </button>
+  );
+}

--- a/src/hooks/useGearUp.ts
+++ b/src/hooks/useGearUp.ts
@@ -369,18 +369,6 @@ export function useGearUp() {
     }
   }, [searchParams]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Listen for planAhead navigation events (resets form even if already on plan mode)
-  useEffect(() => {
-    const onPlanAhead = () => {
-      dispatch({ type: "RESET" });
-      locationSearch.reset();
-      biophysics.reset();
-      dispatch({ type: "SET_INPUT_MODE", mode: "planAhead" });
-    };
-    window.addEventListener("navigatePlanAhead", onPlanAhead);
-    return () => window.removeEventListener("navigatePlanAhead", onPlanAhead);
-  }, [locationSearch, biophysics]);
-
   const handleSubmit = useCallback(async () => {
     if (!activity) {
       toast.error("Please select an activity");

--- a/src/hooks/useTrip.ts
+++ b/src/hooks/useTrip.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { TripFull } from "@/types/trips";
+
+export function useTrip(tripId: string | null) {
+  const [data, setData] = useState<TripFull | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!tripId) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/v1/trips/${tripId}`);
+      if (!res.ok) throw new Error(`Failed (${res.status})`);
+      const body = (await res.json()) as TripFull;
+      setData(body);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load trip");
+    } finally {
+      setLoading(false);
+    }
+  }, [tripId]);
+
+  useEffect(() => {
+    if (!tripId) return;
+    refresh();
+  }, [tripId, refresh]);
+
+  return { data, loading, error, refresh };
+}

--- a/src/lib/trip-activities.ts
+++ b/src/lib/trip-activities.ts
@@ -19,7 +19,10 @@ export type TripActivity = (typeof TRIP_ACTIVITY_OPTIONS)[number];
 // recommendation engine (src/data/activities.ts / layerRecommendations.json).
 // Null entries are sports the engine doesn't support yet — we surface those as
 // gaps in the auto-generated packing list rather than guessing.
-export const TRIP_ACTIVITY_TO_RECOMMENDATION_KEY: Record<string, string | null> = {
+//
+// `satisfies` makes this object a compile error if a TripActivity key is
+// missing or misspelled, while still narrowing each value to string | null.
+export const TRIP_ACTIVITY_TO_RECOMMENDATION_KEY = {
   Alpine: "alpine_skiing",
   Backcountry: "backcountry_skiing",
   XC: "xc_skiing",
@@ -29,9 +32,10 @@ export const TRIP_ACTIVITY_TO_RECOMMENDATION_KEY: Record<string, string | null> 
   Climb: "hiking_snowshoeing", // closest available — load-bearing, slow uphill
   Surf: null,
   Rest: null,
-};
+} satisfies Record<TripActivity, string | null>;
 
 export function tripActivityToRecommendationKey(activity: string | null): string | null {
   if (!activity) return null;
-  return TRIP_ACTIVITY_TO_RECOMMENDATION_KEY[activity] ?? null;
+  if (!(activity in TRIP_ACTIVITY_TO_RECOMMENDATION_KEY)) return null;
+  return TRIP_ACTIVITY_TO_RECOMMENDATION_KEY[activity as TripActivity];
 }

--- a/src/lib/trip-activities.ts
+++ b/src/lib/trip-activities.ts
@@ -36,6 +36,10 @@ export const TRIP_ACTIVITY_TO_RECOMMENDATION_KEY = {
 
 export function tripActivityToRecommendationKey(activity: string | null): string | null {
   if (!activity) return null;
-  if (!(activity in TRIP_ACTIVITY_TO_RECOMMENDATION_KEY)) return null;
+  // hasOwnProperty (not `in`) — `in` would match inherited Object.prototype
+  // keys like "toString" and return the wrong recommendation key.
+  if (!Object.prototype.hasOwnProperty.call(TRIP_ACTIVITY_TO_RECOMMENDATION_KEY, activity)) {
+    return null;
+  }
   return TRIP_ACTIVITY_TO_RECOMMENDATION_KEY[activity as TripActivity];
 }

--- a/src/lib/trip-activities.ts
+++ b/src/lib/trip-activities.ts
@@ -1,0 +1,37 @@
+// Activity chips shown when picking what someone is doing on a trip stop or
+// day. Stored as freeform strings in trip_stops.activities and trip_days.activity
+// so adding new ones requires no DB migration.
+export const TRIP_ACTIVITY_OPTIONS = [
+  "Alpine",
+  "Backcountry",
+  "XC",
+  "Hike",
+  "Run",
+  "Bike",
+  "Surf",
+  "Climb",
+  "Rest",
+] as const;
+
+export type TripActivity = (typeof TRIP_ACTIVITY_OPTIONS)[number];
+
+// Map the trip chip label to the activity key used by the biophysics
+// recommendation engine (src/data/activities.ts / layerRecommendations.json).
+// Null entries are sports the engine doesn't support yet — we surface those as
+// gaps in the auto-generated packing list rather than guessing.
+export const TRIP_ACTIVITY_TO_RECOMMENDATION_KEY: Record<string, string | null> = {
+  Alpine: "alpine_skiing",
+  Backcountry: "backcountry_skiing",
+  XC: "xc_skiing",
+  Hike: "hiking_snowshoeing",
+  Run: "running",
+  Bike: "biking",
+  Climb: "hiking_snowshoeing", // closest available — load-bearing, slow uphill
+  Surf: null,
+  Rest: null,
+};
+
+export function tripActivityToRecommendationKey(activity: string | null): string | null {
+  if (!activity) return null;
+  return TRIP_ACTIVITY_TO_RECOMMENDATION_KEY[activity] ?? null;
+}

--- a/src/lib/trips.ts
+++ b/src/lib/trips.ts
@@ -43,6 +43,7 @@ export async function assertCanAccessTrip(
     .select("id")
     .eq("trip_id", tripId)
     .eq("user_id", userId)
+    .neq("status", "left")
     .maybeSingle();
   return membership ? (trip as Trip) : null;
 }
@@ -59,7 +60,8 @@ export async function listTripsForUser(
   const { data: memberships } = await supabase
     .from("trip_members")
     .select("trip_id")
-    .eq("user_id", userId);
+    .eq("user_id", userId)
+    .neq("status", "left");
 
   const memberTripIds = (memberships ?? []).map((m) => m.trip_id);
   const ownedIds = new Set((owned ?? []).map((t) => t.id));

--- a/src/lib/trips.ts
+++ b/src/lib/trips.ts
@@ -1,0 +1,165 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { randomBytes } from "crypto";
+import type {
+  Trip,
+  TripDay,
+  TripFull,
+  TripGroupGear,
+  TripMember,
+  TripMemberDayKit,
+  TripStop,
+  TripSummary,
+} from "@/types/trips";
+
+export function generateInviteToken(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+export function enumerateDates(startISO: string, endISO: string): string[] {
+  const start = new Date(`${startISO}T00:00:00Z`);
+  const end = new Date(`${endISO}T00:00:00Z`);
+  const out: string[] = [];
+  for (let d = start; d <= end; d = new Date(d.getTime() + 86400000)) {
+    out.push(d.toISOString().slice(0, 10));
+  }
+  return out;
+}
+
+export async function assertCanAccessTrip(
+  supabase: SupabaseClient,
+  tripId: string,
+  userId: string
+): Promise<Trip | null> {
+  const { data: trip } = await supabase
+    .from("trips")
+    .select("*")
+    .eq("id", tripId)
+    .maybeSingle();
+  if (!trip) return null;
+  if (trip.owner_user_id === userId) return trip as Trip;
+
+  const { data: membership } = await supabase
+    .from("trip_members")
+    .select("id")
+    .eq("trip_id", tripId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  return membership ? (trip as Trip) : null;
+}
+
+export async function listTripsForUser(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<TripSummary[]> {
+  const { data: owned } = await supabase
+    .from("trips")
+    .select("*")
+    .eq("owner_user_id", userId);
+
+  const { data: memberships } = await supabase
+    .from("trip_members")
+    .select("trip_id")
+    .eq("user_id", userId);
+
+  const memberTripIds = (memberships ?? []).map((m) => m.trip_id);
+  const ownedIds = new Set((owned ?? []).map((t) => t.id));
+  const extraTripIds = memberTripIds.filter((id) => !ownedIds.has(id));
+
+  let extras: Trip[] = [];
+  if (extraTripIds.length > 0) {
+    const { data } = await supabase
+      .from("trips")
+      .select("*")
+      .in("id", extraTripIds);
+    extras = (data ?? []) as Trip[];
+  }
+
+  const all = [...(owned ?? []), ...extras] as Trip[];
+
+  if (all.length === 0) return [];
+
+  const ids = all.map((t) => t.id);
+  const [{ data: stops }, { data: members }] = await Promise.all([
+    supabase.from("trip_stops").select("trip_id").in("trip_id", ids),
+    supabase
+      .from("trip_members")
+      .select("trip_id, status")
+      .in("trip_id", ids)
+      .neq("status", "left"),
+  ]);
+
+  const stopCount = new Map<string, number>();
+  for (const s of stops ?? []) {
+    stopCount.set(s.trip_id, (stopCount.get(s.trip_id) ?? 0) + 1);
+  }
+  const memberCount = new Map<string, number>();
+  for (const m of members ?? []) {
+    memberCount.set(m.trip_id, (memberCount.get(m.trip_id) ?? 0) + 1);
+  }
+
+  return all
+    .map((t) => ({
+      ...t,
+      stop_count: stopCount.get(t.id) ?? 0,
+      member_count: memberCount.get(t.id) ?? 0,
+    }))
+    .sort((a, b) => a.start_date.localeCompare(b.start_date));
+}
+
+export async function loadTripFull(
+  supabase: SupabaseClient,
+  tripId: string
+): Promise<TripFull | null> {
+  const { data: trip } = await supabase
+    .from("trips")
+    .select("*")
+    .eq("id", tripId)
+    .maybeSingle();
+  if (!trip) return null;
+
+  const [stopsRes, membersRes, daysRes, gearRes] = await Promise.all([
+    supabase.from("trip_stops").select("*").eq("trip_id", tripId).order("position"),
+    supabase.from("trip_members").select("*").eq("trip_id", tripId),
+    supabase.from("trip_days").select("*").eq("trip_id", tripId).order("date"),
+    supabase
+      .from("trip_group_gear")
+      .select("*")
+      .eq("trip_id", tripId)
+      .order("sort_order"),
+  ]);
+
+  const days = (daysRes.data ?? []) as TripDay[];
+  let kits: TripMemberDayKit[] = [];
+  if (days.length > 0) {
+    const { data } = await supabase
+      .from("trip_member_day_kits")
+      .select("*")
+      .in(
+        "trip_day_id",
+        days.map((d) => d.id)
+      );
+    kits = (data ?? []) as TripMemberDayKit[];
+  }
+
+  return {
+    trip: trip as Trip,
+    stops: (stopsRes.data ?? []) as TripStop[],
+    members: (membersRes.data ?? []) as TripMember[],
+    days,
+    kits,
+    gear: (gearRes.data ?? []) as TripGroupGear[],
+  };
+}
+
+export function classifyTripStatus(
+  startISO: string,
+  endISO: string,
+  todayISO = new Date().toISOString().slice(0, 10)
+): "planning" | "next_up" | "live" | "past" {
+  if (endISO < todayISO) return "past";
+  if (startISO <= todayISO && todayISO <= endISO) return "live";
+  const start = new Date(`${startISO}T00:00:00Z`).getTime();
+  const today = new Date(`${todayISO}T00:00:00Z`).getTime();
+  const days = Math.round((start - today) / 86400000);
+  return days <= 14 ? "next_up" : "planning";
+}

--- a/src/lib/userWardrobe.ts
+++ b/src/lib/userWardrobe.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { WardrobeItem } from "@/types/wardrobe";
+
+// Loads every item the user has in their closet with the joined details
+// (garment + thermal properties, or handwear/headwear). Disabled items are
+// included — buildPackingListFromDays decides how to weight them.
+export async function fetchUserWardrobeItems(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<WardrobeItem[]> {
+  const { data: entries, error } = await supabase
+    .from("user_wardrobe")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+  if (error || !entries) return [];
+
+  return Promise.all(
+    entries.map(async (entry) => {
+      let details = null;
+      if (entry.item_type === "garment") {
+        const { data } = await supabase
+          .from("garments")
+          .select("*, garment_thermal_properties(*)")
+          .eq("id", entry.item_id)
+          .single();
+        details = data;
+      } else if (entry.item_type === "handwear") {
+        const { data } = await supabase
+          .from("handwear")
+          .select("*")
+          .eq("id", entry.item_id)
+          .single();
+        details = data;
+      } else if (entry.item_type === "headwear") {
+        const { data } = await supabase
+          .from("headwear")
+          .select("*")
+          .eq("id", entry.item_id)
+          .single();
+        details = data;
+      }
+      return {
+        id: entry.id,
+        item_type: entry.item_type,
+        item_id: entry.item_id,
+        nickname: entry.nickname,
+        disabled: entry.disabled ?? false,
+        created_at: entry.created_at,
+        details,
+      };
+    })
+  );
+}

--- a/src/lib/userWardrobe.ts
+++ b/src/lib/userWardrobe.ts
@@ -4,6 +4,9 @@ import type { WardrobeItem } from "@/types/wardrobe";
 // Loads every item the user has in their closet with the joined details
 // (garment + thermal properties, or handwear/headwear). Disabled items are
 // included — buildPackingListFromDays decides how to weight them.
+//
+// Detail rows are fetched in three batched queries (one per item_type) rather
+// than per-entry to avoid N+1 fan-out on large wardrobes.
 export async function fetchUserWardrobeItems(
   supabase: SupabaseClient,
   userId: string
@@ -15,40 +18,50 @@ export async function fetchUserWardrobeItems(
     .order("created_at", { ascending: false });
   if (error || !entries) return [];
 
-  return Promise.all(
-    entries.map(async (entry) => {
-      let details = null;
-      if (entry.item_type === "garment") {
-        const { data } = await supabase
+  type DetailType = "garment" | "handwear" | "headwear";
+  const idsByType: Record<DetailType, string[]> = {
+    garment: [],
+    handwear: [],
+    headwear: [],
+  };
+  for (const e of entries as Array<{ item_type: string; item_id: string }>) {
+    if (e.item_type === "garment" || e.item_type === "handwear" || e.item_type === "headwear") {
+      idsByType[e.item_type as DetailType].push(e.item_id);
+    }
+  }
+
+  const [garmentsRes, handwearRes, headwearRes] = await Promise.all([
+    idsByType.garment.length > 0
+      ? supabase
           .from("garments")
           .select("*, garment_thermal_properties(*)")
-          .eq("id", entry.item_id)
-          .single();
-        details = data;
-      } else if (entry.item_type === "handwear") {
-        const { data } = await supabase
-          .from("handwear")
-          .select("*")
-          .eq("id", entry.item_id)
-          .single();
-        details = data;
-      } else if (entry.item_type === "headwear") {
-        const { data } = await supabase
-          .from("headwear")
-          .select("*")
-          .eq("id", entry.item_id)
-          .single();
-        details = data;
-      }
-      return {
-        id: entry.id,
-        item_type: entry.item_type,
-        item_id: entry.item_id,
-        nickname: entry.nickname,
-        disabled: entry.disabled ?? false,
-        created_at: entry.created_at,
-        details,
-      };
-    })
-  );
+          .in("id", idsByType.garment)
+      : Promise.resolve({ data: [] }),
+    idsByType.handwear.length > 0
+      ? supabase.from("handwear").select("*").in("id", idsByType.handwear)
+      : Promise.resolve({ data: [] }),
+    idsByType.headwear.length > 0
+      ? supabase.from("headwear").select("*").in("id", idsByType.headwear)
+      : Promise.resolve({ data: [] }),
+  ]);
+
+  const indexById = <T extends { id: string }>(rows: T[] | null) =>
+    new Map<string, T>((rows ?? []).map((row) => [row.id, row]));
+
+  const detailsByType = {
+    garment: indexById((garmentsRes.data ?? []) as Array<{ id: string }>),
+    handwear: indexById((handwearRes.data ?? []) as Array<{ id: string }>),
+    headwear: indexById((headwearRes.data ?? []) as Array<{ id: string }>),
+  };
+
+  return entries.map((entry) => ({
+    id: entry.id,
+    item_type: entry.item_type,
+    item_id: entry.item_id,
+    nickname: entry.nickname ?? undefined,
+    disabled: entry.disabled ?? false,
+    created_at: entry.created_at,
+    details:
+      detailsByType[entry.item_type as keyof typeof detailsByType]?.get(entry.item_id) ?? null,
+  })) as unknown as WardrobeItem[];
 }

--- a/src/lib/userWardrobe.ts
+++ b/src/lib/userWardrobe.ts
@@ -36,14 +36,21 @@ export async function fetchUserWardrobeItems(
           .from("garments")
           .select("*, garment_thermal_properties(*)")
           .in("id", idsByType.garment)
-      : Promise.resolve({ data: [] }),
+      : Promise.resolve({ data: [], error: null }),
     idsByType.handwear.length > 0
       ? supabase.from("handwear").select("*").in("id", idsByType.handwear)
-      : Promise.resolve({ data: [] }),
+      : Promise.resolve({ data: [], error: null }),
     idsByType.headwear.length > 0
       ? supabase.from("headwear").select("*").in("id", idsByType.headwear)
-      : Promise.resolve({ data: [] }),
+      : Promise.resolve({ data: [], error: null }),
   ]);
+
+  // Bail out entirely on any detail-fetch error rather than producing a
+  // wardrobe with missing details — that would surface false "gap" rows in
+  // the packing list and look like the user doesn't own the gear they do.
+  if (garmentsRes.error || handwearRes.error || headwearRes.error) {
+    return [];
+  }
 
   const indexById = <T extends { id: string }>(rows: T[] | null) =>
     new Map<string, T>((rows ?? []).map((row) => [row.id, row]));

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,6 +5,7 @@ const isPublicRoute = createRouteMatcher([
   "/faq",
   "/sign-in(.*)",
   "/sign-up(.*)",
+  "/trips/invite(.*)",
   "/api/geocode(.*)",
   "/api/weather(.*)",
   "/api/v1(.*)",

--- a/src/types/trips.ts
+++ b/src/types/trips.ts
@@ -1,0 +1,80 @@
+export type TripStatus = "planning" | "next_up" | "live" | "past";
+export type TripMemberRole = "organizer" | "member" | "guest";
+export type TripMemberStatus = "joined" | "invited" | "guest" | "left";
+export type TripEffort = "easy" | "steady" | "hard";
+export type TripKitState = "ok" | "warn" | "missing";
+
+export interface Trip {
+  id: string;
+  owner_user_id: string;
+  name: string;
+  start_date: string; // ISO date
+  end_date: string;
+  status: TripStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TripStop {
+  id: string;
+  trip_id: string;
+  position: number;
+  name: string;
+  latitude: number | null;
+  longitude: number | null;
+  activities: string[];
+  created_at: string;
+}
+
+export interface TripMember {
+  id: string;
+  trip_id: string;
+  user_id: string | null;
+  display_name: string;
+  role: TripMemberRole;
+  status: TripMemberStatus;
+  invite_token: string | null;
+  created_at: string;
+}
+
+export interface TripDay {
+  id: string;
+  trip_id: string;
+  stop_id: string | null;
+  date: string;
+  activity: string | null;
+}
+
+export interface TripMemberDayKit {
+  id: string;
+  trip_day_id: string;
+  trip_member_id: string;
+  effort: TripEffort;
+  items: string[];
+  note: string | null;
+  state: TripKitState;
+  updated_at: string;
+}
+
+export interface TripGroupGear {
+  id: string;
+  trip_id: string;
+  description: string;
+  assignee_member_id: string | null;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface TripSummary extends Trip {
+  member_count: number;
+  stop_count: number;
+}
+
+export interface TripFull {
+  trip: Trip;
+  stops: TripStop[];
+  members: TripMember[];
+  days: TripDay[];
+  kits: TripMemberDayKit[];
+  gear: TripGroupGear[];
+}

--- a/supabase/migrations/012_trips.sql
+++ b/supabase/migrations/012_trips.sql
@@ -1,0 +1,146 @@
+-- Trips / Crew (Flow BE)
+-- Top-level "trip" object with stops, members, days, group gear, and per-member day kits.
+
+-- ============================================
+-- ENUMs
+-- ============================================
+
+CREATE TYPE trip_status AS ENUM ('planning', 'next_up', 'live', 'past');
+CREATE TYPE trip_member_role AS ENUM ('organizer', 'member', 'guest');
+CREATE TYPE trip_member_status AS ENUM ('joined', 'invited', 'guest', 'left');
+CREATE TYPE trip_effort AS ENUM ('easy', 'steady', 'hard');
+CREATE TYPE trip_kit_state AS ENUM ('ok', 'warn', 'missing');
+
+-- ============================================
+-- TABLES
+-- ============================================
+
+CREATE TABLE trips (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_user_id VARCHAR(100) NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    status trip_status NOT NULL DEFAULT 'planning',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    CHECK (end_date >= start_date)
+);
+
+CREATE TABLE trip_stops (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+    position INT NOT NULL,
+    name VARCHAR(200) NOT NULL,
+    latitude DECIMAL(8, 4),
+    longitude DECIMAL(8, 4),
+    activities TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (trip_id, position)
+);
+
+CREATE TABLE trip_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+    user_id VARCHAR(100), -- nullable: guests have no Clerk user
+    display_name VARCHAR(120) NOT NULL,
+    role trip_member_role NOT NULL DEFAULT 'member',
+    status trip_member_status NOT NULL DEFAULT 'invited',
+    invite_token VARCHAR(64), -- share-link token for pending invites
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- A real user may only appear once per trip; guests have user_id NULL so we
+-- enforce uniqueness via a partial index instead of a UNIQUE constraint.
+CREATE UNIQUE INDEX idx_trip_members_user_unique
+    ON trip_members (trip_id, user_id)
+    WHERE user_id IS NOT NULL;
+
+CREATE TABLE trip_days (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+    stop_id UUID REFERENCES trip_stops(id) ON DELETE SET NULL,
+    date DATE NOT NULL,
+    activity VARCHAR(80),
+    UNIQUE (trip_id, date)
+);
+
+CREATE TABLE trip_member_day_kits (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trip_day_id UUID NOT NULL REFERENCES trip_days(id) ON DELETE CASCADE,
+    trip_member_id UUID NOT NULL REFERENCES trip_members(id) ON DELETE CASCADE,
+    effort trip_effort NOT NULL DEFAULT 'steady',
+    items JSONB NOT NULL DEFAULT '[]'::jsonb, -- array of layer slot identifiers
+    note TEXT,
+    state trip_kit_state NOT NULL DEFAULT 'ok',
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (trip_day_id, trip_member_id)
+);
+
+CREATE TABLE trip_group_gear (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+    description VARCHAR(200) NOT NULL,
+    assignee_member_id UUID REFERENCES trip_members(id) ON DELETE SET NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ============================================
+-- INDEXES
+-- ============================================
+
+CREATE INDEX idx_trips_owner ON trips(owner_user_id);
+CREATE INDEX idx_trips_dates ON trips(start_date, end_date);
+CREATE INDEX idx_trip_stops_trip ON trip_stops(trip_id);
+CREATE INDEX idx_trip_members_trip ON trip_members(trip_id);
+CREATE INDEX idx_trip_members_user ON trip_members(user_id);
+CREATE INDEX idx_trip_days_trip ON trip_days(trip_id);
+CREATE INDEX idx_trip_member_day_kits_day ON trip_member_day_kits(trip_day_id);
+CREATE INDEX idx_trip_member_day_kits_member ON trip_member_day_kits(trip_member_id);
+CREATE INDEX idx_trip_group_gear_trip ON trip_group_gear(trip_id);
+
+-- ============================================
+-- TRIGGERS
+-- ============================================
+
+CREATE TRIGGER update_trips_updated_at
+    BEFORE UPDATE ON trips
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_trip_member_day_kits_updated_at
+    BEFORE UPDATE ON trip_member_day_kits
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================
+-- ROW LEVEL SECURITY
+-- (Matches existing project convention: USING (true); filtering enforced at
+-- the application layer by passing the authenticated Clerk user id.)
+-- ============================================
+
+ALTER TABLE trips ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trip_stops ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trip_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trip_days ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trip_member_day_kits ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trip_group_gear ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Trips access" ON trips
+    FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "Trip stops access" ON trip_stops
+    FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "Trip members access" ON trip_members
+    FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "Trip days access" ON trip_days
+    FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "Trip member day kits access" ON trip_member_day_kits
+    FOR ALL USING (true) WITH CHECK (true);
+
+CREATE POLICY "Trip group gear access" ON trip_group_gear
+    FOR ALL USING (true) WITH CHECK (true);


### PR DESCRIPTION
## Summary

Implements the full Crew Trip flow (Flow BE) from the claude.ai Design wireframes: trips, multi-stop locations, crew members, per-day kits, group gear, an auto-generated packing list driven by the existing biophysics engine, and a roll-call view. Adds Supabase migration 012 with 6 new tables + RLS, 12 API routes under `/api/v1/trips`, and 8 client routes under `/trips`. Consolidates the bottom nav to a single Trips tab (Plan tab → /trips, drops the `?mode=planAhead` shortcut).

## Highlights

- **DB**: `supabase/migrations/012_trips.sql` — trips, trip_stops, trip_members, trip_days, trip_member_day_kits, trip_group_gear; enums for status/role/effort/kit_state; RLS using the project's existing `USING (true)` + app-layer filter pattern.
- **API**: trip CRUD, stops with reorder, members (real or guest), per-day stop/activity, per-member day kits, group gear, public share-link invite preview + accept, and `GET /api/v1/trips/[id]/pack` which composes `planAhead` + `packingList` to auto-generate a pack list from each day's activity + weather.
- **UI**: `/trips`, `/trips/new` (4-step wizard), `/trips/[id]` overview with color-coded stop ribbon, `/trips/[id]/days/[date]` with inline activity picker, base-location editing, and real Open-Meteo forecast; manage crew, group gear, pack list (with gaps + carry items + wardrobe matching), roll call, and a public invite landing page.
- **Fallbacks**: Days without an assigned stop use the trip's first stop as a base location for both forecasts and the auto pack list.
- **Reuse**: Extracted the wardrobe loader into `src/lib/userWardrobe.ts` so both `/api/packing-list` and the new trip pack endpoint surface owned items.
- **Nav cleanup**: Removed the legacy Plan tab and the dead `navigatePlanAhead` listener; tests updated.

## Test plan

- [x] `npm run build` — verifies all 30+ routes compile (passes locally)
- [x] `npm test` — 380 tests pass locally
- [x] Create a trip via `/trips/new`, verify dates seed `trip_days`
- [x] Add a stop with a geocoded location; verify base-location fallback for unassigned days
- [x] Add a crew member via "Send invite"; share the link, open in another window/session, accept
- [x] Open a day; pick an activity chip; confirm weather card loads (Fahrenheit + mph)
- [x] Open "My pack list"; verify owned items show with "from your closet"; gaps appear for missing slots
- [x] Roll call shows ready/missing dots based on each member's kit completeness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full trip workflow: create, edit, delete trips with date/stop reconciliation and day-level editing
  * Crew management: invite/accept flow, guest support, remove members, and shareable invites
  * Shared gear: add, assign, update, remove group gear
  * Packing lists: weather-informed multi-day packing recommendations and per-day pack view with regenerate
  * Several new trip UI pages: overview, day detail, gear, pack, roll-call, manage, invite, new-trip wizard
* **Tests**
  * Updated navigation tests to reflect new tab set and active-state behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/derobertsw/swttr/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->