### PR TITLE
Make paid MPP agent endpoints fully useful for stateless callers

### DIFF
--- a/docs/paid-agent-api-mpp.md
+++ b/docs/paid-agent-api-mpp.md
@@ -45,6 +45,12 @@ Request flow:
 `307`-redirect unauthenticated agents to sign-in, so `/api/agent(.*)` is listed as a
 public route in `src/proxy.ts` — payment (402), not Clerk, is the gate.
 
+`/api/v1/recommendations/*` itself requires a Clerk session (`src/proxy.ts` returns
+a JSON 401 otherwise), so anonymous callers can't fetch the same response for free.
+The signed-out frontend falls back to static recommendations. The agent routes are
+unaffected — they invoke the v1 handler functions in-process, so the middleware
+gate never runs for paid calls.
+
 > Next 16 renamed `middleware.ts` → `proxy.ts`; the Clerk middleware lives there.
 
 ## Configuration (`.env.local`)
@@ -94,9 +100,36 @@ npx mppx --network testnet -X POST \
   -d '{"weather":{"temperature":45,"wind_speed":5}}'
 ```
 
-Request body matches the v1 routes: `weather.temperature` (°F) and `weather.wind_speed`
-(mph) are required (`src/lib/recommendations/validation.ts`). A successful call returns
-the recommendation JSON and deducts the charge from the caller's testnet balance.
+A successful call returns the recommendation JSON and deducts the charge from the
+caller's testnet balance.
+
+## Request body
+
+Matches the v1 routes (`src/lib/recommendations/validation.ts`), but the agent wrapper
+(`paidRecommendationRoute` in `src/lib/payments/mpp.ts`) validates the body **before**
+issuing the 402 challenge, so a bad request costs nothing.
+
+Required:
+
+- `weather.temperature` (°F)
+- `weather.wind_speed` (mph)
+
+Optional:
+
+- `weather.humidity` (%, default 50), `weather.precipitation` (bool),
+  `weather.precipitation_type`
+- `exertion` (or `intensity`): `easy` | `moderate` | `hard`
+- `height_inches`, `weight_lbs` — body metrics for metabolic adjustment
+  (clamped; defaults 69 in / 170 lbs)
+- `prioritize_light_pack` (bool, ski-touring only)
+
+Rejected with 400: `use_wardrobe_only: true` — wardrobes require a signed-in user,
+which the stateless agent API never has.
+
+Because agent calls are anonymous, garment ensembles and extremity picks
+(handwear/headwear) are selected from the full public catalog rather than a
+user wardrobe; garment candidates are filtered by per-activity suitability
+scores where the schema has them (alpine, xc, ski-touring).
 
 ## Adding a paid route for a new sport
 

--- a/src/app/api/agent/recommendations/alpine/route.ts
+++ b/src/app/api/agent/recommendations/alpine/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { POST as alpineHandler } from '@/app/api/v1/recommendations/alpine/route';
-import { mppx } from '@/lib/payments/mpp';
+import { paidRecommendationRoute } from '@/lib/payments/mpp';
 
 /**
  * POST /api/agent/recommendations/alpine
@@ -8,8 +8,10 @@ import { mppx } from '@/lib/payments/mpp';
  * Paid (MPP / HTTP 402) mirror of POST /api/v1/recommendations/alpine.
  * The `/v1` route stays free for the Clerk-authenticated frontend; machine
  * callers (agents) pay per request here. Recommendation logic is reused from
- * the v1 handler — this file only adds the payment gate.
+ * the v1 handler — this file only adds the payment gate plus pre-charge
+ * body validation so agents aren't charged for guaranteed 400s.
  */
-export const POST = mppx.charge({ amount: process.env.MPP_PRICE_ALPINE ?? '0.02' })(
+export const POST = paidRecommendationRoute(
+  process.env.MPP_PRICE_ALPINE ?? '0.02',
   (request: Request) => alpineHandler(request as NextRequest),
 );

--- a/src/app/api/agent/recommendations/biking/route.ts
+++ b/src/app/api/agent/recommendations/biking/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { POST as bikingHandler } from '@/app/api/v1/recommendations/biking/route';
-import { mppx } from '@/lib/payments/mpp';
+import { paidRecommendationRoute } from '@/lib/payments/mpp';
 
 /**
  * POST /api/agent/recommendations/biking
@@ -8,8 +8,10 @@ import { mppx } from '@/lib/payments/mpp';
  * Paid (MPP / HTTP 402) mirror of POST /api/v1/recommendations/biking.
  * The `/v1` route stays free for the Clerk-authenticated frontend; machine
  * callers (agents) pay per request here. Recommendation logic is reused from
- * the v1 handler — this file only adds the payment gate.
+ * the v1 handler — this file only adds the payment gate plus pre-charge
+ * body validation so agents aren't charged for guaranteed 400s.
  */
-export const POST = mppx.charge({ amount: process.env.MPP_PRICE_BIKING ?? '0.02' })(
+export const POST = paidRecommendationRoute(
+  process.env.MPP_PRICE_BIKING ?? '0.02',
   (request: Request) => bikingHandler(request as NextRequest),
 );

--- a/src/app/api/agent/recommendations/running/route.ts
+++ b/src/app/api/agent/recommendations/running/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { POST as runningHandler } from '@/app/api/v1/recommendations/running/route';
-import { mppx } from '@/lib/payments/mpp';
+import { paidRecommendationRoute } from '@/lib/payments/mpp';
 
 /**
  * POST /api/agent/recommendations/running
@@ -9,8 +9,10 @@ import { mppx } from '@/lib/payments/mpp';
  *
  * The `/v1` route stays free for the Clerk-authenticated frontend; machine
  * callers (agents) pay per request here. All recommendation logic is reused
- * from the v1 handler — this file only adds the payment gate.
+ * from the v1 handler — this file only adds the payment gate plus pre-charge
+ * body validation so agents aren't charged for guaranteed 400s.
  */
-export const POST = mppx.charge({ amount: process.env.MPP_PRICE_RUNNING ?? '0.02' })(
+export const POST = paidRecommendationRoute(
+  process.env.MPP_PRICE_RUNNING ?? '0.02',
   (request: Request) => runningHandler(request as NextRequest),
 );

--- a/src/app/api/agent/recommendations/ski-touring/route.ts
+++ b/src/app/api/agent/recommendations/ski-touring/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { POST as skiTouringHandler } from '@/app/api/v1/recommendations/ski-touring/route';
-import { mppx } from '@/lib/payments/mpp';
+import { paidRecommendationRoute } from '@/lib/payments/mpp';
 
 /**
  * POST /api/agent/recommendations/ski-touring
@@ -8,8 +8,10 @@ import { mppx } from '@/lib/payments/mpp';
  * Paid (MPP / HTTP 402) mirror of POST /api/v1/recommendations/ski-touring.
  * The `/v1` route stays free for the Clerk-authenticated frontend; machine
  * callers (agents) pay per request here. Recommendation logic is reused from
- * the v1 handler — this file only adds the payment gate.
+ * the v1 handler — this file only adds the payment gate plus pre-charge
+ * body validation so agents aren't charged for guaranteed 400s.
  */
-export const POST = mppx.charge({ amount: process.env.MPP_PRICE_SKI_TOURING ?? '0.02' })(
+export const POST = paidRecommendationRoute(
+  process.env.MPP_PRICE_SKI_TOURING ?? '0.02',
   (request: Request) => skiTouringHandler(request as NextRequest),
 );

--- a/src/app/api/agent/recommendations/xc/route.ts
+++ b/src/app/api/agent/recommendations/xc/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { POST as xcHandler } from '@/app/api/v1/recommendations/xc/route';
-import { mppx } from '@/lib/payments/mpp';
+import { paidRecommendationRoute } from '@/lib/payments/mpp';
 
 /**
  * POST /api/agent/recommendations/xc
@@ -8,8 +8,10 @@ import { mppx } from '@/lib/payments/mpp';
  * Paid (MPP / HTTP 402) mirror of POST /api/v1/recommendations/xc.
  * The `/v1` route stays free for the Clerk-authenticated frontend; machine
  * callers (agents) pay per request here. Recommendation logic is reused from
- * the v1 handler — this file only adds the payment gate.
+ * the v1 handler — this file only adds the payment gate plus pre-charge
+ * body validation so agents aren't charged for guaranteed 400s.
  */
-export const POST = mppx.charge({ amount: process.env.MPP_PRICE_XC ?? '0.02' })(
+export const POST = paidRecommendationRoute(
+  process.env.MPP_PRICE_XC ?? '0.02',
   (request: Request) => xcHandler(request as NextRequest),
 );

--- a/src/app/api/v1/recommendations/ski-touring/route.test.ts
+++ b/src/app/api/v1/recommendations/ski-touring/route.test.ts
@@ -329,10 +329,7 @@ describe('Ski Touring Recommendations API Route', () => {
         expect(response.status).not.toBe(400);
       });
 
-      // Note: The current validation uses falsy check for temperature,
-      // which means temperature of 0 is incorrectly rejected.
-      // This test documents the current behavior.
-      it('should reject temperature of 0 due to falsy check (known limitation)', async () => {
+      it('should accept temperature of 0', async () => {
         const mockSupabase = createMockSupabase();
         mockGetSupabase.mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabase>);
 
@@ -341,12 +338,9 @@ describe('Ski Touring Recommendations API Route', () => {
         });
 
         const response = await POST(request);
-        const data = await response.json();
 
-        // Current behavior: 0 is treated as falsy/missing
-        // This could be considered a bug - temperature 0°F is valid
-        expect(response.status).toBe(400);
-        expect(data.error).toBe('weather.temperature and weather.wind_speed are required');
+        // 0°F is a valid winter temperature, not a missing value
+        expect(response.status).not.toBe(400);
       });
 
       it('should handle negative temperatures', async () => {
@@ -599,10 +593,10 @@ describe('Ski Touring Recommendations API Route', () => {
         expect(Array.isArray(packItems.garments)).toBe(true);
       });
 
-      it('should keep descent pack plan wardrobe-only when user wardrobe is empty', () => {
+      it('should build the descent pack from the catalog when user wardrobe is empty', () => {
         const packItems = responseData.pack_items as Record<string, unknown>;
         const garments = packItems.garments as Array<Record<string, unknown>>;
-        expect(garments).toHaveLength(0);
+        expect(garments.length).toBeGreaterThan(0);
       });
 
       it('should include total_weight_g', () => {

--- a/src/app/api/v1/recommendations/ski-touring/route.test.ts
+++ b/src/app/api/v1/recommendations/ski-touring/route.test.ts
@@ -280,7 +280,7 @@ describe('Ski Touring Recommendations API Route', () => {
         const data = await response.json();
 
         expect(response.status).toBe(400);
-        expect(data.error).toBe('weather.temperature and weather.wind_speed are required');
+        expect(data.error).toBe('weather.temperature and weather.wind_speed must be finite numbers');
       });
 
       it('should return 400 when temperature is missing', async () => {
@@ -295,7 +295,7 @@ describe('Ski Touring Recommendations API Route', () => {
         const data = await response.json();
 
         expect(response.status).toBe(400);
-        expect(data.error).toBe('weather.temperature and weather.wind_speed are required');
+        expect(data.error).toBe('weather.temperature and weather.wind_speed must be finite numbers');
       });
 
       it('should return 400 when wind_speed is missing', async () => {
@@ -310,7 +310,7 @@ describe('Ski Touring Recommendations API Route', () => {
         const data = await response.json();
 
         expect(response.status).toBe(400);
-        expect(data.error).toBe('weather.temperature and weather.wind_speed are required');
+        expect(data.error).toBe('weather.temperature and weather.wind_speed must be finite numbers');
       });
     });
 
@@ -341,6 +341,33 @@ describe('Ski Touring Recommendations API Route', () => {
 
         // 0°F is a valid winter temperature, not a missing value
         expect(response.status).not.toBe(400);
+      });
+
+      it('should return 400 for null temperature', async () => {
+        const mockSupabase = createMockSupabase();
+        mockGetSupabase.mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabase>);
+
+        const request = createRequest({
+          weather: { temperature: null, wind_speed: 10 },
+        });
+
+        const response = await POST(request);
+
+        // null would coerce to a bogus 0°F recommendation — reject it
+        expect(response.status).toBe(400);
+      });
+
+      it('should return 400 for non-numeric temperature', async () => {
+        const mockSupabase = createMockSupabase();
+        mockGetSupabase.mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabase>);
+
+        const request = createRequest({
+          weather: { temperature: 'cold', wind_speed: 10 },
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(400);
       });
 
       it('should handle negative temperatures', async () => {
@@ -961,6 +988,56 @@ describe('Ski Touring Recommendations API Route', () => {
         g => g.toLowerCase().includes('breathability') || g.toLowerCase().includes('evap')
       );
       expect(hasBreathabilityGuidance).toBe(true);
+    });
+  });
+
+  describe('Descent pack suitability (catalog callers)', () => {
+    // Insulation that only clears the uphill threshold — qualifies for the
+    // touring catalog (uphill OR downhill >= 6) but is unfit for the descent pack.
+    const uphillOnlyInsulation = {
+      ...createMockInsulation(),
+      id: 'garment-ins-uphill-only',
+      garment_activity_ratings: {
+        ski_touring_uphill_score: 8,
+        ski_touring_downhill_score: 4,
+      },
+    };
+
+    it('should exclude uphill-only insulation from the descent pack', async () => {
+      const mockSupabase = createMockSupabase({
+        garments: [createMockGarment(), createMockLegsBaseLayer(), uphillOnlyInsulation],
+      });
+      mockGetSupabase.mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabase>);
+
+      const request = createRequest({
+        weather: { temperature: 10, wind_speed: 10 },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      const packItems = data.pack_items as Record<string, unknown>;
+      const garments = packItems.garments as Array<Record<string, unknown>>;
+      expect(garments.some((g) => g.id === 'garment-ins-uphill-only')).toBe(false);
+    });
+
+    it('should include downhill-suitable insulation in the descent pack', async () => {
+      // createMockInsulation has ski_touring_downhill_score: 9
+      const mockSupabase = createMockSupabase({
+        garments: [createMockGarment(), createMockLegsBaseLayer(), createMockInsulation()],
+      });
+      mockGetSupabase.mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabase>);
+
+      const request = createRequest({
+        weather: { temperature: 10, wind_speed: 10 },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      const packItems = data.pack_items as Record<string, unknown>;
+      const garments = packItems.garments as Array<Record<string, unknown>>;
+      expect(garments.length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/app/api/v1/recommendations/ski-touring/route.ts
+++ b/src/app/api/v1/recommendations/ski-touring/route.ts
@@ -267,12 +267,11 @@ export async function POST(request: NextRequest) {
   const uphillThermalProperties = predictEnsembleThermal(uphillThermalGarments);
   const uphillTotalClo = uphillThermalProperties.rcl.wholeBody;
 
-  // Pack Items
-  const packInsulationCandidates = hasUserWardrobe ? categorizedGarments.insulation : [];
+  // Pack Items — catalog callers get candidates too (suitableGarments is
+  // already score-filtered for them above)
+  const packInsulationCandidates = categorizedGarments.insulation;
   const uphillIds = new Set(uphillEnsemble.map((g) => g.id));
-  const packShellCandidates = hasUserWardrobe
-    ? categorizedGarments.shells.filter((s) => !uphillIds.has(s.id))
-    : [];
+  const packShellCandidates = categorizedGarments.shells.filter((s) => !uphillIds.has(s.id));
   const additionalCloNeeded = Math.max(0, ireqDownhill.ireqNeutral - uphillTotalClo);
   const packInsulationLayer = selectPackableInsulation(
     packInsulationCandidates, additionalCloNeeded, shouldPrioritizeLightPack

--- a/src/app/api/v1/recommendations/ski-touring/route.ts
+++ b/src/app/api/v1/recommendations/ski-touring/route.ts
@@ -267,9 +267,15 @@ export async function POST(request: NextRequest) {
   const uphillThermalProperties = predictEnsembleThermal(uphillThermalGarments);
   const uphillTotalClo = uphillThermalProperties.rcl.wholeBody;
 
-  // Pack Items — catalog callers get candidates too (suitableGarments is
-  // already score-filtered for them above)
-  const packInsulationCandidates = categorizedGarments.insulation;
+  // Pack items are descent gear. Catalog callers draw from suitableGarments
+  // (uphill OR downhill >= 6), so restrict the descent pack to insulation that
+  // actually clears the downhill threshold. Wardrobe garments stay unfiltered —
+  // they're the user's own kit and may lack activity ratings.
+  const packInsulationCandidates = hasUserWardrobe
+    ? categorizedGarments.insulation
+    : categorizedGarments.insulation.filter(
+        (g) => (g.garment_activity_ratings?.ski_touring_downhill_score ?? 0) >= 6
+      );
   const uphillIds = new Set(uphillEnsemble.map((g) => g.id));
   const packShellCandidates = categorizedGarments.shells.filter((s) => !uphillIds.has(s.id));
   const additionalCloNeeded = Math.max(0, ireqDownhill.ireqNeutral - uphillTotalClo);

--- a/src/lib/payments/mpp.ts
+++ b/src/lib/payments/mpp.ts
@@ -64,9 +64,16 @@ export function paidRecommendationRoute(
     const weather = body?.weather as
       | { temperature?: unknown; wind_speed?: unknown }
       | undefined;
-    if (!body || weather?.temperature === undefined || weather?.wind_speed === undefined) {
+    // Mirror validateRecommendationRequest: both fields must be finite numbers
+    // (0 allowed). Rejecting here avoids charging for a request the v1 handler
+    // would 400 anyway.
+    if (
+      !body ||
+      !Number.isFinite(weather?.temperature) ||
+      !Number.isFinite(weather?.wind_speed)
+    ) {
       return NextResponse.json(
-        { error: 'weather.temperature and weather.wind_speed are required' },
+        { error: 'weather.temperature and weather.wind_speed must be finite numbers' },
         { status: 400 },
       );
     }

--- a/src/lib/payments/mpp.ts
+++ b/src/lib/payments/mpp.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server';
 import { Mppx, tempo } from 'mppx/nextjs';
 
 /**
@@ -34,3 +35,52 @@ export const mppx = Mppx.create({
     }),
   ],
 });
+
+/**
+ * Wrap a paid recommendation route with pre-charge validation.
+ *
+ * Bodies that would fail (or come back guaranteed-empty) in the v1 handler are
+ * rejected with a 400 before the 402 challenge is ever issued, so agents don't
+ * pay for a response they can't use:
+ * - missing `weather.temperature` / `weather.wind_speed` (required by
+ *   `validateRecommendationRequest`)
+ * - `use_wardrobe_only: true` — wardrobes require a signed-in user, which the
+ *   stateless agent API never has
+ */
+export function paidRecommendationRoute(
+  amount: string,
+  handler: (request: Request) => Promise<Response>,
+): (request: Request) => Promise<Response> {
+  const charged = mppx.charge({ amount })(handler);
+
+  return async (request: Request) => {
+    let body: Record<string, unknown> | null = null;
+    try {
+      body = await request.clone().json();
+    } catch {
+      body = null;
+    }
+
+    const weather = body?.weather as
+      | { temperature?: unknown; wind_speed?: unknown }
+      | undefined;
+    if (!body || weather?.temperature === undefined || weather?.wind_speed === undefined) {
+      return NextResponse.json(
+        { error: 'weather.temperature and weather.wind_speed are required' },
+        { status: 400 },
+      );
+    }
+
+    if (body.use_wardrobe_only === true) {
+      return NextResponse.json(
+        {
+          error:
+            'use_wardrobe_only is not supported on the agent API — wardrobes require a signed-in user. Omit the flag to get catalog recommendations.',
+        },
+        { status: 400 },
+      );
+    }
+
+    return charged(request);
+  };
+}

--- a/src/lib/recommendations/database.test.ts
+++ b/src/lib/recommendations/database.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchUserHandwear, fetchUserHeadwear, fetchGarmentsWithDetails } from './database';
+import type { getSupabase } from '@/lib/supabase';
+
+type SupabaseStub = NonNullable<ReturnType<typeof getSupabase>>;
+
+interface QueryResult {
+  data: unknown;
+  error: null;
+}
+
+function createStubQuery(result: QueryResult) {
+  const query = {
+    in: vi.fn(() => query),
+    gte: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    then: (resolve: (value: QueryResult) => unknown) => resolve(result),
+  };
+  return query;
+}
+
+function createStubSupabase(resultsByTable: Record<string, QueryResult>) {
+  const selects: Record<string, string> = {};
+  const supabase = {
+    from: vi.fn((table: string) => ({
+      select: vi.fn((columns: string) => {
+        selects[table] = columns;
+        return createStubQuery(resultsByTable[table] ?? { data: [], error: null });
+      }),
+    })),
+  };
+  return { supabase: supabase as unknown as SupabaseStub, selects };
+}
+
+const catalogHandwear = [
+  { id: 'h1', brand: 'A', model_name: 'Glove', handwear_type: 'glove', rcl_clo: 0.2 },
+  { id: 'h2', brand: 'B', model_name: 'Mitt', handwear_type: 'mitten', rcl_clo: 0.5 },
+];
+
+const catalogHeadwear = [
+  { id: 'b1', brand: 'A', model_name: 'Beanie', headwear_type: 'midweight_beanie', rcl_clo: 0.1 },
+];
+
+describe('fetchUserHandwear', () => {
+  it('falls back to the full catalog for anonymous callers', async () => {
+    const { supabase } = createStubSupabase({
+      handwear: { data: catalogHandwear, error: null },
+    });
+
+    const result = await fetchUserHandwear(supabase, null);
+
+    expect(result).toEqual(catalogHandwear);
+  });
+
+  it('returns empty for signed-in users with no wardrobe handwear', async () => {
+    const { supabase } = createStubSupabase({
+      user_wardrobe: { data: [], error: null },
+      handwear: { data: catalogHandwear, error: null },
+    });
+
+    const result = await fetchUserHandwear(supabase, 'user_123');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('fetchUserHeadwear', () => {
+  it('falls back to the full catalog for anonymous callers', async () => {
+    const { supabase } = createStubSupabase({
+      headwear: { data: catalogHeadwear, error: null },
+    });
+
+    const result = await fetchUserHeadwear(supabase, null);
+
+    expect(result).toEqual(catalogHeadwear);
+  });
+
+  it('returns empty for signed-in users with no wardrobe headwear', async () => {
+    const { supabase } = createStubSupabase({
+      user_wardrobe: { data: [], error: null },
+      headwear: { data: catalogHeadwear, error: null },
+    });
+
+    const result = await fetchUserHeadwear(supabase, 'user_123');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('fetchGarmentsWithDetails', () => {
+  it('uses an inner join on activity ratings when an activity filter is set', async () => {
+    const { supabase, selects } = createStubSupabase({
+      garments: { data: [], error: null },
+    });
+
+    await fetchGarmentsWithDetails(supabase, {
+      activityFilter: { field: 'alpine_skiing_score', minScore: 5 },
+    });
+
+    expect(selects.garments).toContain('garment_activity_ratings!inner (*)');
+  });
+
+  it('uses a plain embed when fetching wardrobe garments', async () => {
+    const { supabase, selects } = createStubSupabase({
+      garments: { data: [], error: null },
+    });
+
+    await fetchGarmentsWithDetails(supabase, { wardrobeIds: ['g1'] });
+
+    expect(selects.garments).toContain('garment_activity_ratings (*)');
+    expect(selects.garments).not.toContain('!inner');
+  });
+});

--- a/src/lib/recommendations/database.ts
+++ b/src/lib/recommendations/database.ts
@@ -37,13 +37,18 @@ export async function fetchGarmentsWithDetails(
     };
   }
 ): Promise<{ data: GarmentRow[] | null; error: Error | null }> {
+  const useActivityFilter =
+    !(options?.wardrobeIds && options.wardrobeIds.length > 0) && Boolean(options?.activityFilter);
+
+  // `!inner` is required for the .gte() below to drop garments under the score
+  // threshold — without it PostgREST only nulls the embed and returns every row.
   let query = supabase
     .from('garments')
     .select(`
       *,
       garment_thermal_properties (*),
       garment_protection (*),
-      garment_activity_ratings (*)
+      ${useActivityFilter ? 'garment_activity_ratings!inner (*)' : 'garment_activity_ratings (*)'}
     `);
 
   if (options?.wardrobeIds && options.wardrobeIds.length > 0) {
@@ -91,6 +96,12 @@ export async function fetchUserHandwear(
   supabase: NonNullable<ReturnType<typeof getSupabase>>,
   userId: string | null
 ): Promise<HandwearRow[]> {
+  // Anonymous callers (agent API) have no wardrobe — select from the full catalog.
+  if (!userId) {
+    const { data } = await supabase.from('handwear').select('*');
+    return (data as HandwearRow[]) || [];
+  }
+
   const ids = await getUserWardrobeItemIds(supabase, userId, 'handwear');
   if (!ids || ids.length === 0) return [];
 
@@ -109,6 +120,12 @@ export async function fetchUserHeadwear(
   supabase: NonNullable<ReturnType<typeof getSupabase>>,
   userId: string | null
 ): Promise<HeadwearRow[]> {
+  // Anonymous callers (agent API) have no wardrobe — select from the full catalog.
+  if (!userId) {
+    const { data } = await supabase.from('headwear').select('*');
+    return (data as HeadwearRow[]) || [];
+  }
+
   const ids = await getUserWardrobeItemIds(supabase, userId, 'headwear');
   if (!ids || ids.length === 0) return [];
 

--- a/src/lib/recommendations/validation.ts
+++ b/src/lib/recommendations/validation.ts
@@ -39,9 +39,15 @@ export async function validateRecommendationRequest(
   const userId = await getAuthUserId();
   const body = await request.json();
 
-  if (body.weather?.temperature === undefined || body.weather?.wind_speed === undefined) {
+  // Require finite numbers (0°F/0mph are valid), rejecting undefined, null,
+  // booleans, and non-numeric strings that would otherwise coerce to a bogus
+  // temperature in fahrenheitToCelsius.
+  if (
+    !Number.isFinite(body.weather?.temperature) ||
+    !Number.isFinite(body.weather?.wind_speed)
+  ) {
     return NextResponse.json(
-      { error: 'weather.temperature and weather.wind_speed are required' },
+      { error: 'weather.temperature and weather.wind_speed must be finite numbers' },
       { status: 400 }
     );
   }

--- a/src/lib/recommendations/validation.ts
+++ b/src/lib/recommendations/validation.ts
@@ -39,7 +39,7 @@ export async function validateRecommendationRequest(
   const userId = await getAuthUserId();
   const body = await request.json();
 
-  if (!body.weather?.temperature || body.weather?.wind_speed === undefined) {
+  if (body.weather?.temperature === undefined || body.weather?.wind_speed === undefined) {
     return NextResponse.json(
       { error: 'weather.temperature and weather.wind_speed are required' },
       { status: 400 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 const isPublicRoute = createRouteMatcher([
   "/",
@@ -13,7 +14,30 @@ const isPublicRoute = createRouteMatcher([
   "/api/agent(.*)",
 ]);
 
+// Clerk-gated even though /api/v1 is otherwise public: anonymous callers would
+// get the same response the paid /api/agent mirror charges for. The agent
+// routes invoke the v1 handlers in-process, so this gate never runs for them.
+// The signed-out frontend degrades gracefully to static recommendations
+// (useBiophysicsRecommendation swallows non-OK responses).
+const isGatedRecommendationRoute = createRouteMatcher([
+  "/api/v1/recommendations(.*)",
+]);
+
 export default clerkMiddleware(async (auth, request) => {
+  if (isGatedRecommendationRoute(request)) {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json(
+        {
+          error:
+            "Authentication required — machine callers should use the paid /api/agent/recommendations endpoints",
+        },
+        { status: 401 }
+      );
+    }
+    return;
+  }
+
   if (!isPublicRoute(request)) {
     await auth.protect();
   }


### PR DESCRIPTION
## What problem(s) was I solving?

The paid agent API (`/api/agent/recommendations/*`, MPP / HTTP 402) reuses the v1 handlers, but machine callers are stateless — no Clerk user, no wardrobe. On that path several things silently degraded:

- **Handwear/headwear were always `null`** (wardrobe-only fetches), and the comfort scorer counted the missing extremities as 0 clo, dragging down `thermal_comfort_score` in cold conditions with no way for the caller to fix it.
- **Ski-touring pack items were hard-coded empty** for non-wardrobe callers, so paid responses never included descent insulation — plus a spurious "insufficient insulation for descent" warning.
- **The alpine/xc activity filter was a PostgREST no-op**: `.gte()` on the `garment_activity_ratings` embed without `!inner` doesn't filter parent rows, so the whole catalog (85 garments) was considered instead of the suitable subset (73 for alpine).
- **Agents could be charged for guaranteed-useless responses**: invalid bodies and `use_wardrobe_only: true` paid first, then got a 400/empty result. A falsy check also rejected `temperature: 0` (°F) as missing.
- **The paid API was trivially bypassable**: `/api/v1(.*)` was public, so anonymous callers could fetch the identical response free at `/api/v1/recommendations/*`.

## What user-facing changes did I ship?

- Paid agent responses now include handwear/headwear picks and ski-touring pack items selected from the full public catalog, with honest comfort scores.
- Agents get an immediate, free 400 for missing weather fields or `use_wardrobe_only` — validation runs before the 402 challenge.
- Anonymous requests to `/api/v1/recommendations/*` now return a JSON 401 pointing at the paid endpoints. The signed-out web UI degrades gracefully to static recommendations (`useBiophysicsRecommendation` swallows non-OK responses); signed-in users are unaffected.
- `temperature: 0` °F is now accepted (v1 and agent routes).

## How I implemented it

- `src/lib/recommendations/database.ts`: `fetchUserHandwear`/`fetchUserHeadwear` fall back to the full `handwear`/`headwear` catalogs when `userId === null` (public-read RLS, `001_schema.sql`); signed-in behavior unchanged. `fetchGarmentsWithDetails` uses a `garment_activity_ratings!inner (*)` embed when an activity filter is set.
- `src/app/api/v1/recommendations/ski-touring/route.ts`: removed the `hasUserWardrobe ? … : []` guards on pack insulation/shell candidates (catalog callers are already score-filtered ≥ 6).
- `src/lib/payments/mpp.ts`: new `paidRecommendationRoute()` wrapper (validate → charge → handler) used by all five agent routes.
- `src/proxy.ts`: a `/api/v1/recommendations(.*)` matcher returns a JSON 401 before the public-route check; the rest of `/api/v1` stays public (the public invite page needs `/api/v1/trips/invite/*`). Paid agent calls are unaffected because they invoke the v1 handler functions in-process, bypassing middleware.
- `src/lib/recommendations/validation.ts`: `!temperature` → `temperature === undefined`.
- Docs: request-body reference and the new auth gate in `docs/paid-agent-api-mpp.md`.

## How to verify it

- [x] `npx vitest run` — 33 files, 387 tests pass (includes new `database.test.ts` covering the catalog fallback and the `!inner` embed; two stale ski-touring tests that pinned the old behavior were updated)
- [x] `npx tsc --noEmit` — same 11 pre-existing errors before and after (all in unrelated hook/component test files)

### Test Plan

All performed against `npm run dev` with the live Supabase project:

- [x] Anonymous `POST /api/v1/recommendations/running` → 401 JSON; `/api/v1/ireq` → 200; `/api/v1/trips/invite/<bogus>` → 404 (handler self-auths, middleware doesn't block)
- [x] Agent route, missing `wind_speed` → immediate 400; `use_wardrobe_only: true` → immediate 400; valid body unpaid → 402 challenge
- [x] Full paid loop via `npx mppx --network testnet` for running and ski-touring: payment settled (testnet balance deducted), responses include catalog extremities (e.g. "Outdoor Research Firebrand Mitt") and pack items ("Patagonia Micro Puff Hoody" + transition-protocol step)
- [x] REST-level proof of the filter fix: plain embed returns all 85 garments; `!inner` returns 73 with `alpine_skiing_score ≥ 5`
- [x] Visual check of the signed-out home page falling back to static recommendations (code path verified; UI not eyeballed)

## Description for the changelog

Paid agent recommendation endpoints now return complete catalog-based recommendations (including handwear, headwear, and ski-touring pack items) for stateless callers, validate requests before charging, and the free v1 recommendation routes now require sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Clerk session gating for free recommendation endpoints (anonymous requests now return `401`).
  * Introduced a paid recommendation routing wrapper with standardized request validation and clearer `400`/`402` behavior.
* **Bug Fixes**
  * Recommendation request validation now correctly accepts `weather.temperature: 0` and rejects non-finite values.
  * Ski-touring pack selection now properly falls back to catalog items when wardrobes are empty, and updates descent/uphill suitability.
  * Improved activity-based garment filtering and anonymous catalog selection behavior.
* **Tests**
  * Expanded ski-touring and recommendation database unit test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->